### PR TITLE
Memory BW model and fix for MG flop count

### DIFF
--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -194,6 +194,7 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
         test_data.times_comp[i] = 0.0;
         test_data.times_comm[i] = 0.0;
     }
+    test_data.ctrs_bench.reset();
 
     for (int i=0; i < numberOfGmresCalls; ++i) {
       x.fill_zero();
@@ -239,21 +240,24 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
                  << (flops/1000000000.0)/time_solve_total
                  << " (n = " << A.totalNumberOfRows << ")" << endl;
     }
-    test_data.optTotalFlops = test_data.flops[0];
     test_data.optTotalTime = time_solve_total;
     test_data.numOfCalls = numberOfGmresCalls;
 
     test_data.optNumOfMGCalls = test_data.numOfMGCalls;
     test_data.optNumOfSPCalls = test_data.numOfSPCalls;
-    //test_data.opt_flops = (double*)malloc(num_flops * sizeof(double));
-    //test_data.opt_times = (double*)malloc(num_times * sizeof(double));
-    for (int i=0; i<n_fl_ops; i++) test_data.opt_flops[i] = test_data.flops[i];
-    for (int i=0; i<n_timed_ops; i++) test_data.opt_times[i] = test_data.times[i];
+    for (int i=0; i<n_fl_ops; i++)
+        test_data.opt_flops[i] = test_data.flops[i];
+    test_data.opt_flops[1] = test_data.ctrs_bench.mg_gs.get_total_flops() +
+                             test_data.ctrs_bench.mg_rp.get_total_flops();
+    test_data.opt_flops[0] += test_data.opt_flops[1];
+    test_data.optTotalFlops = test_data.opt_flops[0];
+    for (int i=0; i<n_timed_ops; i++)
+        test_data.opt_times[i] = test_data.times[i];
 
-    //test_data.opt_times_comp = (double*)malloc(num_times * sizeof(double));
-    //test_data.opt_times_comm = (double*)malloc(num_times * sizeof(double));
-    for (int i=0; i<n_timed_ops; i++) test_data.opt_times_comp[i] = test_data.times_comp[i];
-    for (int i=0; i<n_timed_ops; i++) test_data.opt_times_comm[i] = test_data.times_comm[i];
+    for (int i=0; i<n_timed_ops; i++)
+        test_data.opt_times_comp[i] = test_data.times_comp[i];
+    for (int i=0; i<n_timed_ops; i++)
+        test_data.opt_times_comm[i] = test_data.times_comm[i];
   }
 
   const double benchmark_done = mytimer();
@@ -275,11 +279,17 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
 
     double time_solve_total = 0.0;
 
+    for (int i=0; i<n_fl_ops; i++) {
+        test_data.flops[i] = 0.0;
+    }
+    for (int i=0; i<n_timed_ops; i++) {
+        test_data.times[i] = 0.0;
+        test_data.times_comp[i] = 0.0;
+        test_data.times_comm[i] = 0.0;
+    }
+    test_data.ctrs_ref.reset();
+
     //benchmark runs
-    for (int i=0; i<n_fl_ops; i++) test_data.flops[i] = 0.0;
-    for (int i=0; i<n_timed_ops; i++) test_data.times[i] = 0.0;
-    for (int i=0; i<n_timed_ops; i++) test_data.times_comp[i] = 0.0;
-    for (int i=0; i<n_timed_ops; i++) test_data.times_comm[i] = 0.0;
     for (int i=0; i< n_ref_calls; ++i) {
       x.fill_zero();
 
@@ -315,20 +325,23 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
                  << " = " << (flops/1000000000.0)/time_solve_total 
                  << " (n = " << A.totalNumberOfRows << ")" << endl;
     }
-    test_data.refTotalFlops = test_data.flops[0];
     test_data.refTotalTime  = test_data.times[0];
 
     test_data.refNumOfMGCalls = test_data.numOfMGCalls;
     test_data.refNumOfSPCalls = test_data.numOfSPCalls;
-    //test_data.ref_flops = (double*)malloc(num_flops * sizeof(double));
-    //test_data.ref_times = (double*)malloc(num_times * sizeof(double));
-    for (int i=0; i<n_fl_ops; i++) test_data.ref_flops[i] = test_data.flops[i];
-    for (int i=0; i<n_timed_ops; i++) test_data.ref_times[i] = test_data.times[i];
+    for (int i=0; i<n_fl_ops; i++)
+        test_data.ref_flops[i] = test_data.flops[i];
+    test_data.ref_flops[1] = test_data.ctrs_ref.mg_gs.get_total_flops() +
+                             test_data.ctrs_ref.mg_rp.get_total_flops();
+    test_data.ref_flops[0] += test_data.ref_flops[1];
+    test_data.refTotalFlops = test_data.ref_flops[0];
+    for (int i=0; i<n_timed_ops; i++)
+        test_data.ref_times[i] = test_data.times[i];
 
-    //test_data.ref_times_comp = (double*)malloc(num_times * sizeof(double));
-    //test_data.ref_times_comm = (double*)malloc(num_times * sizeof(double));
-    for (int i=0; i<n_timed_ops; i++) test_data.ref_times_comp[i] = test_data.times_comp[i];
-    for (int i=0; i<n_timed_ops; i++) test_data.ref_times_comm[i] = test_data.times_comm[i];
+    for (int i=0; i<n_timed_ops; i++)
+        test_data.ref_times_comp[i] = test_data.times_comp[i];
+    for (int i=0; i<n_timed_ops; i++)
+        test_data.ref_times_comm[i] = test_data.times_comm[i];
   } else {
     test_data.refTotalFlops = 0.0;
     test_data.refTotalTime  = 0.0;
@@ -405,6 +418,8 @@ void test_mg_spmv(MPI_Comm comm, DeviceCtx *const dctx, const Geometry *const ge
     int ierr = 0;
     const int numberOfCalls = 10;
     const double t_begin = mytimer();
+    double mgtime = 0, t0 = 0;
+    perf_counters ft, ft0;
     for (int i=0; i< numberOfCalls; ++i) {
       ierr = ComputeSPMV(A, x_overlap, b_computed); // b_computed = A*x_overlap
 #ifdef HPGMP_VERBOSE
@@ -413,8 +428,14 @@ void test_mg_spmv(MPI_Comm comm, DeviceCtx *const dctx, const Geometry *const ge
       }
 #endif
       if (ierr) HPGMP_fout << "Error in call to SpMV: " << ierr << ".\n" << endl;
-      flops_and_traffic ft;
-      ierr = ComputeMG(A, b_computed, x_overlap, symmetric, ft); // b_computed = Minv*y_overlap
+
+      if(i == 0) {
+          ierr = ComputeMG(A, b_computed, x_overlap, symmetric, ft0); // b_computed = Minv*y_overlap
+      } else {
+          TICK();
+          ierr = ComputeMG(A, b_computed, x_overlap, symmetric, ft); // b_computed = Minv*y_overlap
+          TOCK(mgtime);
+      }
       if (ierr) HPGMP_fout << "Error in call to MG: " << ierr << ".\n" << endl;
     }
 #ifdef HPGMP_VERBOSE
@@ -424,4 +445,13 @@ void test_mg_spmv(MPI_Comm comm, DeviceCtx *const dctx, const Geometry *const ge
 #endif
     // Total time divided by number of calls.
     test_data.SpmvMgTime = (mytimer() - t_begin)/((double) numberOfCalls);
+
+    const double mgbytes = ft.mg_gs.get_total_memory_bytes() + ft.mg_rp.get_total_memory_bytes();
+    const double mgflops = ft.mg_gs.get_total_flops() + ft.mg_rp.get_total_flops();
+    if(geom->rank == 0) {
+        std::cout << "BenchGMRES:  test_mg_spmv: MG = " << mgbytes / mgtime / 1e9
+            << " GB/s" << std::endl;
+        std::cout << "BenchGMRES:  test_mg_spmv: MG = " << mgflops / mgtime / 1e9
+            << " GFLOP/s" << std::endl;
+    }
 }

--- a/src/ComputeGEMV_gpu.cpp
+++ b/src/ComputeGEMV_gpu.cpp
@@ -119,6 +119,7 @@ int ComputeGEMV_ref(const local_int_t m, const local_int_t n,
   } else {
     HPGMP_vout << " Mixed-precision GEMV not supported" << std::endl;
     HPGMP_fout << " Mixed-precision GEMV not supported" << std::endl;
+    throw std::runtime_error("Mixed-precision GEMV is currently very inefficient!");
 
     y.update_host_mirror();
     A.update_host_mirror();

--- a/src/ComputeMG.cpp
+++ b/src/ComputeMG.cpp
@@ -49,7 +49,7 @@
  */
 template<class SparseMatrix_type, class Vector_type>
 int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & x,
-              const bool symmetric, flops_and_traffic& ft)
+              const bool symmetric, perf_counters& ft)
 {
   using scalar_type = typename SparseMatrix_type::scalar_type;
   const int mpisize = A.geom->size;
@@ -57,7 +57,8 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
   // Optimized versions of calls
   double t0 = 0.0;
   x.fill_zero();
-  ft.f_mem_traffic[0] += x.local_length();
+  //ft.mg_rp.f_mem_traffic[0] += x.local_length();
+  ft.mg_rp.add_memory_traffic<scalar_type>(mpisize*x.local_length());
 
   std::shared_ptr<const ELLMatrix<scalar_type>> mat =
       dynamic_cast<EllOptData<scalar_type>*>(A.optimizationData)->mat;
@@ -75,10 +76,19 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     for(int i=0; i < numberOfPresmootherSteps; ++i) {
       if(i = 0) {
         ierr += ell_multicolor_gs_zero_initial(symmetric, mat.get(), &r, &x);
-        ft.flops[0] += A.totalNumberOfNonzeros;
+        //ft.mg_gs.flops[0] += A.totalNumberOfNonzeros;
+        ft.mg_gs.add_flops<scalar_type>(A.totalNumberOfNonzeros);
+        // the first color is treated differently:
+        ft.mg_gs.add_memory_traffic<scalar_type>(
+                3.0*A.totalNumberOfRows/8 + 7.0/8*(A.totalNumberOfNonzeros+A.totalNumberOfRows-1)/2+1
+                + 2*A.totalNumberOfRows);
+        ft.mg_gs.add_memory_traffic<int>(7.0/8*A.totalNumberOfNonzeros);
       } else {
         ierr += ell_multicolor_gs(symmetric, mat.get(), &r, &x);
-        ft.flops[0] += 2*A.totalNumberOfNonzeros;
+        //ft.mg_gs.flops[0] += 2*A.totalNumberOfNonzeros;
+        ft.mg_gs.add_flops<scalar_type>(2*A.totalNumberOfNonzeros);
+        ft.mg_gs.add_memory_traffic<scalar_type>(A.totalNumberOfNonzeros + 2*A.totalNumberOfRows);
+        ft.mg_gs.add_memory_traffic<int>(A.totalNumberOfNonzeros);
       }
     }
     x.time1_ = 0.0;  // Apparently no one cares about GS comm time
@@ -93,10 +103,15 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     TICK();
     //ierr = restriction(A, r);
     ierr = fused_spmv_restriction(A, r, x);
-    ft.flops[0] += 2*A.Ac->totalNumberOfNonzeros;
+    TOCK(x.time3_);
+    //ft.mg_rp.flops[0] += 2*A.Ac->totalNumberOfNonzeros;
+    const auto coarse_len = A.Ac->totalNumberOfRows;
+    ft.mg_rp.add_flops<scalar_type>(2*A.Ac->totalNumberOfNonzeros);
+    ft.mg_rp.add_memory_traffic<local_int_t>(3*coarse_len + A.Ac->totalNumberOfNonzeros);
+    ft.mg_rp.add_memory_traffic<scalar_type>(coarse_len + A.Ac->totalNumberOfNonzeros
+                                             + A.totalNumberOfRows);
     if (ierr!=0)
       return ierr;
-    TOCK(x.time3_);
 
     // MG on coarser-grid
     A.mgData->xc->time1_ = A.mgData->xc->time2_ = 0.0;
@@ -110,10 +125,13 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     // Prolongation operation
     TICK();
     ierr = prolongation(A, x);
-    ft.flops[0] += mpisize*A.mgData->rc->local_length();
+    TOCK(x.time4_);
+    //ft.mg_rp.flops[0] += mpisize*A.mgData->rc->local_length();
+    ft.mg_rp.add_flops<scalar_type>(coarse_len);
+    ft.mg_rp.add_memory_traffic<local_int_t>(coarse_len*3);
+    ft.mg_rp.add_memory_traffic<scalar_type>(coarse_len*2);
     if (ierr!=0)
       return ierr;
-    TOCK(x.time4_);
 
     // Post-smoothing
     time_gs_sofar = x.time2_;
@@ -123,7 +141,10 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     const int numberOfPostsmootherSteps = A.mgData->numberOfPostsmootherSteps;
     for (int i=0; i< numberOfPostsmootherSteps; ++i) {
       ierr += ell_multicolor_gs(symmetric, mat.get(), &r, &x);
-      ft.flops[0] += 2*A.totalNumberOfNonzeros;
+      //ft.mg_gs.flops[0] += 2*A.totalNumberOfNonzeros;
+      ft.mg_gs.add_flops<scalar_type>(2*A.totalNumberOfNonzeros);
+      ft.mg_gs.add_memory_traffic<scalar_type>(A.totalNumberOfNonzeros + 2*A.totalNumberOfRows);
+      ft.mg_gs.add_memory_traffic<local_int_t>(A.totalNumberOfNonzeros);
     }
     x.time1_ = 0.0;  // Apparently no one cares about GS comm time
     // restore GS time so far
@@ -144,7 +165,10 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     // restore GS time so far
     x.time2_ = time_gs_sofar;
     TOCK(x.time2_);
-    ft.flops[0] += 2*A.totalNumberOfNonzeros;
+    //ft.mg_gs.flops[0] += 2*A.totalNumberOfNonzeros;
+    ft.mg_gs.add_flops<scalar_type>(2*A.totalNumberOfNonzeros);
+    ft.mg_gs.add_memory_traffic<scalar_type>(A.totalNumberOfNonzeros + 2*A.totalNumberOfRows);
+    ft.mg_gs.add_memory_traffic<local_int_t>(A.totalNumberOfNonzeros);
     if (ierr!=0)
       return ierr;
   }
@@ -158,9 +182,9 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
 
 template
 int ComputeMG(SparseMatrix<double> const&, Vector<double> const&, Vector<double>&, bool,
-              flops_and_traffic&);
+              perf_counters&);
 
 template
 int ComputeMG(SparseMatrix<float> const&, Vector<float> const&, Vector<float>&, bool,
-              flops_and_traffic&);
+              perf_counters&);
 

--- a/src/ComputeMG.hpp
+++ b/src/ComputeMG.hpp
@@ -20,9 +20,10 @@
 #include "hpgmp.hpp"
 #include "SparseMatrix.hpp"
 #include "Vector.hpp"
+#include "perf_counter.hpp"
 
 template<class SparseMatrix_type, class Vector_type>
 int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & x,
-              bool symmetric, flops_and_traffic& ft);
+              bool symmetric, perf_counters& ft);
 
 #endif // COMPUTEMG_HPP

--- a/src/ComputeWAXPBY_gpu.cpp
+++ b/src/ComputeWAXPBY_gpu.cpp
@@ -197,13 +197,15 @@ int ComputeWAXPBY_ref(const local_int_t n,
     int rank = 0;
     MPI_Comm_rank(x.comm, &rank);
     if (rank == 0) {
-      HPGMP_fout << rank << " : WAXPBY(" << n << "): error = " << enorm << " (alpha=" << alpha << ", beta=" << beta
-	        << ", x=" << xnorm << ", y=" << ynorm << ", w=" << wnorm << ")" << std::endl;
+      HPGMP_fout << rank << " : WAXPBY(" << n << "): error = " << enorm << " (alpha=" << alpha
+                 << ", beta=" << beta << ", x=" << xnorm << ", y=" << ynorm << ", w=" << wnorm
+                 << ")" << std::endl;
     }
     free(tv);
 #endif
   } else {
     HPGMP_vout << " Mixed-precision WAXPBY on host, since not supported on device" << std::endl;
+    throw std::runtime_error(" Mixed-precision WAXPBY on host, since not supported on device");
 
     const scalarX_type * const xv = x.values();
     const scalarY_type * const yv = y.values();

--- a/src/GMRES.cpp
+++ b/src/GMRES.cpp
@@ -35,6 +35,7 @@
 #include "ComputeTRSM.hpp"
 #include "ComputeGEMV.hpp"
 #include "ComputeGEMVT.hpp"
+#include "perf_counter.hpp"
 
 
 /*!
@@ -63,8 +64,8 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
           const typename SparseMatrix_type::scalar_type tolerance,
           int & niters, typename SparseMatrix_type::scalar_type & normr,
           typename SparseMatrix_type::scalar_type & normr0,
-          const bool doPreconditioning, const bool verbose, TestGMRESData_type& test_data) {
- 
+          const bool doPreconditioning, const bool verbose, TestGMRESData_type& test_data)
+{
   typedef typename SparseMatrix_type::scalar_type scalar_type;
   typedef MultiVector<scalar_type> MultiVector_type;
   typedef SerialDenseMatrix<scalar_type> SerialDenseMatrix_type;
@@ -115,38 +116,42 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
       HPGMP_fout << "WARNING: PERFORMING UNPRECONDITIONED ITERATIONS" << std::endl;
 
   double flops = 0.0;
-  double flops_gmg  = 0.0;
   double flops_spmv = 0.0;
   double flops_orth = 0.0;
   const global_int_t numSpMVs_MG = 1 +
       A.mgData->numberOfPresmootherSteps + A.mgData->numberOfPostsmootherSteps;
   niters = 0;
   bool converged = false;
+  perf_counters& ctrs = test_data.ctrs_ref;
   double t_begin = mytimer();  // Start timing right away
   while (niters <= max_iter && !converged)
   {
-    flops_and_traffic mgft;
-    for(int i = 0; i < flops_and_traffic::n_precs; i++) {
-        mgft.flops[i] = 0.0;
-        mgft.f_mem_traffic[i] = 0.0;
-    }
-    mgft.i_mem_traffic = 0.0;
-
     // p is of length ncols, copy x to p for sparse MV operation
     // In HIP/Cuda builds, this copies only device buffers.
     CopyVector(x, p);
-    TICK(); ComputeSPMV(A, p, Ap); TOCK(t3); flops_spmv += (2*A.totalNumberOfNonzeros); // Ap = A*p
+    ctrs.vecupd.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
+
+    // Ap = A*p
+    TICK(); ComputeSPMV(A, p, Ap); TOCK(t3); flops_spmv += (2*A.totalNumberOfNonzeros);
+    ctrs.spmv.add_memory_traffic<scalar_type>(A.totalNumberOfNonzeros + 2*A.totalNumberOfRows);
+    ctrs.spmv.add_memory_traffic<local_int_t>(A.totalNumberOfNonzeros);
 
     TICK(); ComputeWAXPBY(nrow, one, b, -one, Ap, r, A.isWaxpbyOptimized); TOCK(t11);
     flops += (itwo*Nrow); // r = b - Ax (x stored in p)
+    ctrs.vecupd.add_memory_traffic<scalar_type>(3*A.totalNumberOfRows);
 
     TICK(); ComputeDotProduct(nrow, r, r, normr, t4, A.isDotProductOptimized);
+    ctrs.ortho.add_memory_traffic<scalar_type>(A.totalNumberOfRows);
     flops += (itwo*Nrow); TOCK(t1);
     normr = sqrt(normr);
 
     auto Qj = Q.get_vector(0);
     CopyVector(r, Qj);
+    ctrs.vecupd.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
+
+    // TODO: Fuse with above copy operation
     TICK(); Qj.scale(one/normr); TOCK(t11); flops += Nrow;
+    ctrs.vecupd.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
 
     // Record initial residual for convergence testing
     if (niters == 0) normr0 = normr;
@@ -168,6 +173,8 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
     // Start restart cycle
     int k = 1;
     t.set_value(0, 0, normr);
+    ctrs.qr_host.add_memory_traffic<scalar_type>(1);
+
     //HPGMP_VERBOSE_PRINT("GMRES: Starting restart cycle..");
     while (k <= restart_length && normr/normr0 > tolerance) { // Use ">" to exit when res=zero (continuing will cause NaN)
       auto Qkm1 = Q.get_vector(k-1);
@@ -176,17 +183,18 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
       TICK();
       if (doPreconditioning) {
         z.time1_ = z.time2_ = z.time3_ = z.time4_ = 0.0;
-        ComputeMG(A, Qkm1, z, symmetric, mgft);
-        //flops_gmg += (2*numSpMVs_MG*A.totalNumberOfMGNonzeros); // Apply preconditioner
+        ComputeMG(A, Qkm1, z, symmetric, ctrs);
         t7 += z.time1_; t8 += z.time2_; t9 += z.time3_; t10 += z.time4_;
       } else {
         CopyVector(Qkm1, z);              // copy r to z (no preconditioning)
+        ctrs.vecupd.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
       }
       TOCK(t5); // Preconditioner apply time
 
       // Qk = A*z
       TICK(); ComputeSPMV(A, z, Qk); flops_spmv += (2*A.totalNumberOfNonzeros); TOCK(t3);
-
+      ctrs.spmv.add_memory_traffic<scalar_type>(A.totalNumberOfNonzeros + 2*A.totalNumberOfRows);
+      ctrs.spmv.add_memory_traffic<local_int_t>(A.totalNumberOfNonzeros);
 
       // orthogonalize z against Q(:,0:k-1), using dots
       TICK();
@@ -211,32 +219,45 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
 #endif
         // CGS2
         auto P = Q.get_multi_vector(0, k-1);
-        // Computes GEMV^T and copies output h to host
-        START_T(); ComputeGEMVT (nrow, k,  one, P, Qk, zero, h, A.isGemvOptimized); STOP_T(t1); // h = Q(1:k)'*q(k+1)
-        // Copies input h to device and Computes GEMV
-        START_T(); ComputeGEMV  (nrow, k, -one, P, h,  one, Qk, A.isGemvOptimized); STOP_T(t2); // h = Q(1:k)'*q(k+1)
+        // Computes GEMV^T and copies output h to host: h = Q(1:k)'*q(k+1)
+        START_T(); ComputeGEMVT (nrow, k,  one, P, Qk, zero, h, A.isGemvOptimized); STOP_T(t1);
+        ctrs.ortho.add_memory_traffic<scalar_type>((k+1)*A.totalNumberOfRows + k);
+
+        // Copies input h to device and Computes GEMV: qk <- qk - P*h
+        START_T(); ComputeGEMV  (nrow, k, -one, P, h, one, Qk, A.isGemvOptimized); STOP_T(t2);
+        ctrs.ortho.add_memory_traffic<scalar_type>((k+2)*A.totalNumberOfRows + k);
         t1_comp += h.time1; t1_comm += h.time2;
         for(int i = 0; i < k; i++) {
           H.set_value(i, k-1, h.values()[i]);
         }
         flops_orth += (ifour*k*Nrow);
-        // reorthogonalize
-        START_T(); ComputeGEMVT (nrow, k,  one, P, Qk, zero, h, A.isGemvOptimized); STOP_T(t1); // h = Q(1:k)'*q(k+1)
-        START_T(); ComputeGEMV  (nrow, k, -one, P, h,  one, Qk, A.isGemvOptimized); STOP_T(t2); // h = Q(1:k)'*q(k+1)
+        ctrs.qr_host.add_memory_traffic<scalar_type>(2*k);
+
+        // reorthogonalize: h = Q(1:k)'*q(k+1)
+        START_T(); ComputeGEMVT (nrow, k,  one, P, Qk, zero, h, A.isGemvOptimized); STOP_T(t1);
+        ctrs.ortho.add_memory_traffic<scalar_type>((k+1)*A.totalNumberOfRows + k);
+
+        // Copies input h to device and Computes GEMV: qk <- qk - P*h
+        START_T(); ComputeGEMV  (nrow, k, -one, P, h,  one, Qk, A.isGemvOptimized); STOP_T(t2);
         t1_comp += h.time1; t1_comm += h.time2;
+        ctrs.ortho.add_memory_traffic<scalar_type>((k+2)*A.totalNumberOfRows + k);
+
         for(int i = 0; i < k; i++) {
           H.add_value(i, k-1, h.values()[i]);
         }
+        ctrs.qr_host.add_memory_traffic<scalar_type>(3*k);
         flops_orth += (ifour*k*Nrow);
         // end CGS2
 
       // beta = norm(Qk)
       START_T(); ComputeDotProduct(nrow, Qk, Qk, beta, t4, A.isDotProductOptimized); STOP_T(t1);
       flops_orth += (itwo*Nrow);
+      ctrs.ortho.add_memory_traffic<scalar_type>(A.totalNumberOfRows);
       beta = sqrt(beta);
 
       // Qk = Qk / beta
       START_T(); Qk.scale(one/beta); STOP_T(t11);
+      ctrs.vecupd.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
       flops_orth += (Nrow);
 
       TOCK(t6); // Ortho time
@@ -253,6 +274,7 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
         H.set_value(j+1, k-1, -sj * h1 + cj * h2);
         H.set_value(j,   k-1,  cj * h1 + sj * h2);
       }
+      ctrs.qr_host.add_memory_traffic<scalar_type>((k-2)*6+1);
 
       const double f = H.get_value(k-1, k-1);
       const double g = H.get_value(k,   k-1);
@@ -275,6 +297,8 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
       ss.set_value(k-1, 0, sj);
       cs.set_value(k-1, 0, cj);
 
+      ctrs.qr_host.add_memory_traffic<scalar_type>(6);
+
       normr = std::abs(v2);
       if (verbose && A.geom->rank==0 && (k%print_freq == 0 || k+1 == restart_length)) {
         HPGMP_fout << "GMRES Iteration = "<< k << " (" << niters << ")   Scaled Residual = "
@@ -289,26 +313,34 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
     }
     // > update x
     ComputeTRSM(k-1, one, H, t);
+    ctrs.qr_host.add_memory_traffic<scalar_type>(
+            restart_length*restart_length/2.0 + 3.0*restart_length/2);
     if (doPreconditioning) {
       // r = Q*t. t is on host, so ComputeGEMV first copies it to device before computation
       ComputeGEMV(nrow, k-1, one, Q, t, zero, r, A.isGemvOptimized);
       flops += (itwo*Nrow*(k-ione));
+      ctrs.ortho.add_memory_traffic<scalar_type>((A.totalNumberOfRows+1)*restart_length
+                                                 + A.totalNumberOfRows);
 
       z.time1_ = z.time2_ = z.time3_ = z.time4_ = 0.0;
       TICK();
-      ComputeMG(A, r, z, symmetric, mgft);
-      //flops_gmg += (2*numSpMVs_MG*A.totalNumberOfMGNonzeros);      // z = M*r
+      ComputeMG(A, r, z, symmetric, ctrs);
       TOCK(t5); // Preconditioner apply time
       t7 += z.time1_; t8 += z.time2_; t9 += z.time3_; t10 += z.time4_;
 
+      // x += z
       TICK(); ComputeWAXPBY(nrow, one, x, one, z, x, A.isWaxpbyOptimized); TOCK(t11);
-      flops += (itwo*Nrow); // x += z
+      flops += (itwo*Nrow);
+      ctrs.vecupd.add_memory_traffic<scalar_type>(3*A.totalNumberOfRows);
     } else {
       // x += Q*t
       ComputeGEMV(nrow, k-1, one, Q, t, one, x, A.isGemvOptimized); flops += (itwo*Nrow*(k-ione));
+      ctrs.ortho.add_memory_traffic<scalar_type>((A.totalNumberOfRows+1)*restart_length
+                                                 + 2*A.totalNumberOfRows);
     }
-    flops_gmg += mgft.flops[0];
   } // end of outer-loop
+    
+  //const double flops_gmg = ctrs.mg_gs.get_total_flops() + ctrs.mg_rp.get_total_flops();
 
 
   // Store times
@@ -320,8 +352,8 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
   test_data.times[4]  += t3;  // SPMV time
   test_data.times[5]  += t4;  // AllReduce time
   test_data.times[6]  += t5;  // preconditioner apply time
-  test_data.times[7]  += t7;  // > SpTRSV for GS
-  test_data.times[8]  += t8;  // > SpMV for GS
+  test_data.times[7]  += t7;  // > SpMV for GS
+  test_data.times[8]  += t8;  // > GS
   test_data.times[9]  += t9;  // > Restrict for GS
   test_data.times[10] += t10; // > Prolong for GS
   test_data.times[11] += t11; // Vector update time
@@ -331,14 +363,16 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
 //#ifndef HPGMP_NO_MPI
 //  times[6] += t6; // exchange halo time
 //#endif
-  double flops_tot = flops + flops_gmg + flops_spmv + flops_orth;
+  //const double flops_tot = flops + flops_gmg + flops_spmv + flops_orth;
+  // MG flops will be added later in BenchGMRES from test_data.ctrs_ref.
+  const double flops_tot = flops + flops_spmv + flops_orth;
   if (verbose && A.geom->rank==0) {
     HPGMP_fout << " > nnz(A)  : " << A.totalNumberOfNonzeros << std::endl;
     HPGMP_fout << " > nnz(MG) : " << A.totalNumberOfMGNonzeros << " (" << numSpMVs_MG << ")" << std::endl;
     HPGMP_fout << " > SpMV : " << (flops_spmv / 1000000000.0) << " / " << t3 << " = "
                               << (flops_spmv / 1000000000.0) / t3 << " Gflop/s" << std::endl;
-    HPGMP_fout << " > GMG  : " << (flops_gmg  / 1000000000.0) << " / " << t5 << " = "
-                              << (flops_gmg  / 1000000000.0) / t5 << " Gflop/s" << std::endl;
+    //HPGMP_fout << " > GMG  : " << (flops_gmg  / 1000000000.0) << " / " << t5 << " = "
+    //                          << (flops_gmg  / 1000000000.0) / t5 << " Gflop/s" << std::endl;
     HPGMP_fout << " > Orth : " << (flops_orth / 1000000000.0) << " / " << t6 << " = "
                               << (flops_orth / 1000000000.0) / t6 << " Gflop/s" << std::endl;
     HPGMP_fout << " > Total: " << (flops_tot  / 1000000000.0) << " / " << tt << " = "
@@ -346,7 +380,7 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
     HPGMP_fout << std::endl;
   }
   test_data.flops[0] += flops_tot;
-  test_data.flops[1] += flops_gmg;
+  //test_data.flops[1] += flops_gmg;
   test_data.flops[2] += flops_spmv;
   test_data.flops[3] += flops_orth;
 

--- a/src/GMRESData.hpp
+++ b/src/GMRESData.hpp
@@ -26,6 +26,7 @@
 #include <array>
 #include "Vector.hpp"
 #include "SparseMatrix.hpp"
+#include "perf_counter.hpp"
 
 template <class SC, class PSC = SC>
 class GMRESData {
@@ -103,7 +104,11 @@ public:
   double refTotalTime;  //
   double optTotalFlops; //
   double optTotalTime;  //
-  //!< flop counts and time for total, dot, axpy, ortho, spmv, reduce, precond
+  
+  perf_counters ctrs_ref;   ///< Counting for flops and memory traffic
+  perf_counters ctrs_bench; ///< Counting for flops and memory traffic of different precisions
+
+  //! flop counts and time for total, dot, axpy, ortho, spmv, reduce, precond
   std::array<double,n_fl_ops> flops;        //!< accumulated in GMRES, temporary workspace
   std::array<double,n_timed_ops> times;        //!< accumulated in GMRES, temporary workspace
   std::array<double,n_timed_ops> times_comp;   //!< accumulated in GMRES, temporary workspace

--- a/src/GMRES_IR.cpp
+++ b/src/GMRES_IR.cpp
@@ -148,7 +148,6 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
       HPGMP_fout << " Projection precision : float" << std::endl;
   }
   double flops = 0.0;
-  double flops_gmg  = 0.0;
   double flops_spmv = 0.0;
   double flops_orth = 0.0;
   const global_int_t numSpMVs_MG = 1 + A.mgData->numberOfPresmootherSteps
@@ -156,29 +155,31 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
   niters = 0;
   bool converged = false;
   double t_begin = mytimer();  // Start timing right away
+ 
+  perf_counters& ctrs = test_data.ctrs_bench;
+ 
   while (niters <= max_iter && !converged)
   {
-    flops_and_traffic mgft;
-    for(int i = 0; i < flops_and_traffic::n_precs; i++) {
-        mgft.flops[i] = 0.0;
-        mgft.f_mem_traffic[i] = 0.0;
-    }
-    mgft.i_mem_traffic = 0.0;
-
     // > Compute residual vector (higher working precision)
     // p is of length ncols, copy x to p for sparse MV operation
     CopyVector(x_hi, p_hi);
+    ctrs.vecupd.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
 
     p_hi.time1_ = 0; p_hi.time2_ = 0;
     TICK(); ComputeSPMV(A, p_hi, Ap_hi);            // Ap = A*p
     flops_spmv += (2*A.totalNumberOfNonzeros);
     TOCK(t3);
     t3_1 += p_hi.time1_; t3_2 += p_hi.time2_;
+    ctrs.spmv.add_memory_traffic<scalar_type>(A.totalNumberOfNonzeros + 2*A.totalNumberOfRows);
+    ctrs.spmv.add_memory_traffic<local_int_t>(A.totalNumberOfNonzeros);
 
     TICK(); ComputeWAXPBY_opt(nrow, one_hi, b_hi, -one_hi, Ap_hi, r_hi, A.isWaxpbyOptimized);
     flops += (itwo*Nrow);  TOCK(t11); // r = b - Ax (x stored in p)
+    ctrs.vecupd.add_memory_traffic<scalar_type>(3*A.totalNumberOfRows);
+
     TICK(); ComputeDotProduct(nrow, r_hi, r_hi, normr_hi, t4, A.isDotProductOptimized);
     flops += (itwo*Nrow); TOCK(t1_);
+    ctrs.ortho.add_memory_traffic<scalar_type>(A.totalNumberOfRows);
     normr_hi = sqrt(normr_hi);
     test_data.numOfSPCalls++;
     // Record initial residual for convergence testing
@@ -216,13 +217,14 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
 
     // > Scale to the residual vector in working precision
     TICK();
-    //ScaleVectorValue<Vector_type, scalar_type> (r_hi, one_hi/normr_hi);
     r_hi.scale(one_hi/normr_hi);
     flops += Nrow; TOCK(t11);
+    ctrs.vecupd.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
 
     // > Copy r as the initial basis vector (lower precision)
     auto Qj = Q.get_vector(0);
     CopyVector(r_hi, Qj);
+    ctrs.vecupd.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
 
     // do forward GS instead of symmetric GS
     const bool symmetric = false;
@@ -230,6 +232,7 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
     // Start restart cycle
     global_int_t k = 1;
     t.set_value(0, 0, normr);
+    ctrs.qr_host.add_memory_traffic<project_type>(1);
     while (k <= restart_length && normr/normr0 > tolerance && !IS_NAN(normr))
     {
       // Use ">" to exit when res=zero (continuing will cause NaN)
@@ -240,12 +243,12 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
       if (doPreconditioning) {
         z.time1_ = z.time2_ = z.time3_ = z.time4_ = 0.0;
         // Apply preconditioner
-        ComputeMG(A_lo, Qkm1, z, symmetric, mgft);
-        //flops_gmg += (2*numSpMVs_MG*A.totalNumberOfMGNonzeros);
+        ComputeMG(A_lo, Qkm1, z, symmetric, ctrs);
         test_data.numOfMGCalls++;
         t7 += z.time1_; t8 += z.time2_; t9 += z.time3_; t10 += z.time4_;
       } else {
         CopyVector(Qkm1, z);       // copy r to z (no preconditioning)
+        ctrs.vecupd.add_memory_traffic<scalar_type2>(2*A.totalNumberOfRows);
       }
       TOCK(t5); // Preconditioner apply time
 
@@ -256,6 +259,8 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
       TOCK(t3);
       t3_1 += z.time1_; t3_2 += z.time2_;
       test_data.numOfSPCalls++;
+      ctrs.spmv.add_memory_traffic<scalar_type2>(A.totalNumberOfNonzeros + 2*A.totalNumberOfRows);
+      ctrs.spmv.add_memory_traffic<local_int_t>(A.totalNumberOfNonzeros);
 
       // orthogonalize z against Q(:,0:k-1), using dots
       bool use_mgs = false;
@@ -271,15 +276,18 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
             // beta = Qk'*Qj
             START_T(); ComputeDotProduct<Vector_type2, project_type>
                          (nrow, Qk, Qj, beta, t4, A.isDotProductOptimized); STOP_T(t1);
+            ctrs.ortho.add_memory_traffic<scalar_type2>(2*A.totalNumberOfRows);
 
             // Qk = Qk - beta * Qj
             START_T(); ComputeWAXPBY_opt(nrow, one, Qk, -beta, Qj, Qk, A.isWaxpbyOptimized);
             STOP_T(t2);
+            ctrs.ortho.add_memory_traffic<scalar_type2>(3*A.totalNumberOfRows);
             alpha += beta;
           }
           H.set_value(j, k-1, alpha);
         }
         flops_orth += (ifour*k*Nrow);
+        ctrs.qr_host.add_memory_traffic<project_type>(2*k);
       } else {
         // CGS2
         // first orthogonalization
@@ -288,26 +296,39 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
         // Batched dot to compute components along previoud vectors h = Q(1:k)'*q(k+1)
         // mul and add in proj_type
         START_T(); ComputeGEMVT (nrow, k,  one, P, Qk, zero_pr, h, A.isGemvOptimized); STOP_T(t1);
+        ctrs.ortho.add_memory_traffic<scalar_type2>((k+1)*A.totalNumberOfRows);
+        ctrs.ortho.add_memory_traffic<project_type>(k);
         // Subtract components along previous vectors to orthogonalize: q(k+1) = q(k+1) - Q(1:k)*h
         START_T(); ComputeGEMV  (nrow, k, -one, P, h,  one,    Qk, A.isGemvOptimized); STOP_T(t2);
         t1_comp += h.time1; t1_comm += h.time2;
+        ctrs.ortho.add_memory_traffic<scalar_type2>((k+2)*A.totalNumberOfRows);
+        ctrs.ortho.add_memory_traffic<project_type>(k);
+
         for(int i = 0; i < k; i++) {
           H.set_value(i, k-1, h.values()[i]);
         }
         flops_orth += (ifour*k*Nrow);
+        ctrs.qr_host.add_memory_traffic<project_type>(2*k);
 
         START_T();
         // reorthogonalization
         // h = Q(1:k)'*q(k+1)
         ComputeGEMVT (nrow, k,  one, P, Qk, zero_pr, h, A.isGemvOptimized);
         STOP_T(t1);
+        ctrs.ortho.add_memory_traffic<scalar_type2>((k+1)*A.totalNumberOfRows);
+        ctrs.ortho.add_memory_traffic<project_type>(k);
+
         // q(k+1) = q(k+1) - Q(1:k)*h
         START_T(); ComputeGEMV (nrow, k, -one, P, h,  one, Qk, A.isGemvOptimized); STOP_T(t2);
         t1_comp += h.time1; t1_comm += h.time2;
+        ctrs.ortho.add_memory_traffic<scalar_type2>((k+2)*A.totalNumberOfRows);
+        ctrs.ortho.add_memory_traffic<project_type>(k);
+
         for(int i = 0; i < k; i++) {
           H.add_value(i, k-1, h.values()[i]);
         }
         flops_orth += (ifour*k*Nrow);
+        ctrs.qr_host.add_memory_traffic<project_type>(2*k);
       } // end or CGS2
 
       // beta = norm(Qk)
@@ -316,11 +337,13 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
                                                     A.isDotProductOptimized);
       STOP_T(t1_);
       flops_orth += (itwo*Nrow);
+      ctrs.ortho.add_memory_traffic<scalar_type2>(A.totalNumberOfRows);
       beta = sqrt(beta);
 
       // Qk = Qk / beta
       // NOTE: Qk is scalar_type2, so the scaling factor is cast to this type before scaling.
       START_T(); Qk.scale(static_cast<scalar_type2>(one_pr/beta)); STOP_T(t11);
+      ctrs.vecupd.add_memory_traffic<scalar_type2>(2*A.totalNumberOfRows);
       flops_orth += (Nrow);
 
       TOCK(t6); // Ortho time
@@ -336,6 +359,7 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
         H.set_value(j+1, k-1, -sj * h1 + cj * h2);
         H.set_value(j,   k-1,  cj * h1 + sj * h2);
       }
+      ctrs.qr_host.add_memory_traffic<project_type>((k-2)*6+1);
 
       const auto f = static_cast<project_type>(H.get_value(k-1, k-1));
       const auto g = static_cast<project_type>(H.get_value(k,   k-1));
@@ -357,6 +381,8 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
 
       ss.set_value(k-1, 0, sj);
       cs.set_value(k-1, 0, cj);
+      
+      ctrs.qr_host.add_memory_traffic<project_type>(6);
 
       normr = std::abs(v2);
       if (verbose && (k%print_freq == 0 || k+1 == restart_length)) {
@@ -371,11 +397,11 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
           if (doPreconditioning) {
             #ifdef HPGMRES_IR_UPDATE_X_IN_HIGH
             ComputeGEMV(nrow, k, one, Q, h, zero_hi, r_hi, A.isGemvOptimized);  // r = Q*t (using h for t)
-            ComputeMG(A_lo, r_hi, z_hi, symmetric, mgft);                       // z = M*r
+            ComputeMG(A_lo, r_hi, z_hi, symmetric, ctrs);                       // z = M*r
             ComputeWAXPBY_opt(nrow, one_hi, p_hi, one_hi, z_hi, p_hi, A.isWaxpbyOptimized); // x += z
             #else
             ComputeGEMV(nrow, k, one, Q, h, zero, r, A.isGemvOptimized);    // r = Q*t (using h for t)
-            ComputeMG(A_lo, r, z, symmetric, mgft);                         // z = M*r
+            ComputeMG(A_lo, r, z, symmetric, ctrs);                         // z = M*r
             ComputeWAXPBY_opt(nrow, one_hi, p_hi, one, z, p_hi, A.isWaxpbyOptimized);    // x += z
             #endif
           } else {
@@ -422,32 +448,38 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
       HPGMP_fout << "GMRES_IR restart: k = "<< k << " (" << niters << ")" << std::endl;
     // > update x
     ComputeTRSM(k-1, one_pr, H, t);
+    ctrs.qr_host.add_memory_traffic<project_type>(
+            restart_length*restart_length/2.0 + 3.0*restart_length/2);
     if (doPreconditioning) {
 #ifdef HPGMRES_IR_UPDATE_X_IN_HIGH
       ComputeGEMV (nrow, k-1, one, Q, t, zero_hi, r_hi, A.isGemvOptimized);
       flops += (itwo*Nrow*(k-ione)); // r = Q*t
+      ctrs.ortho.add_memory_traffic<scalar_type2>((A.totalNumberOfRows+1)*restart_length);
+      ctrs.ortho.add_memory_traffic<scalar_type>(A.totalNumberOfRows);
+      ctrs.ortho.add_memory_traffic<project_type>(restart_length);
 
       z_hi.time1_ = z_hi.time2_ = z_hi.time3_ = z_hi.time4_ = 0.0;
       TICK();
-      ComputeMG(A, r_hi, z_hi, symmetric, mgft);
-      //flops_gmg += (2*numSpMVs_MG*A.totalNumberOfMGNonzeros);    // z = M*r
+      ComputeMG(A, r_hi, z_hi, symmetric, ctrs);
       TOCK(t5); // Preconditioner apply time
       test_data.numOfMGCalls++;
       t7 += z_hi.time1_; t8 += z_hi.time2_; t9 += z_hi.time3_; t10 += z_hi.time4_;
 
-      // (mixed-precision) x += z
+      // x += z
       TICK(); ComputeWAXPBY_opt(nrow, one_hi, x_hi, one_hi, z_hi, x_hi, A.isWaxpbyOptimized);
+      ctrs.vecupd.add_memory_traffic<scalar_type>(3*A.totalNumberOfRows);
       flops += (itwo*Nrow); TOCK(t11);
 #else
       // r = Q*t
       ComputeGEMV (nrow, k-1, one, Q, t, zero, r, A.isGemvOptimized);
       flops += (itwo*Nrow*(k-ione));
+      ctrs.ortho.add_memory_traffic<scalar_type2>(A.totalNumberOfRows*(restart_length+1));
+      ctrs.ortho.add_memory_traffic<project_type>(restart_length);
 
       z.time1_ = z.time2_ = z.time3_ = z.time4_ = 0.0;
       TICK();
       // z = M*r
-      ComputeMG(A_lo, r, z, symmetric, mgft);
-      //flops_gmg += (2*numSpMVs_MG*A.totalNumberOfMGNonzeros);
+      ComputeMG(A_lo, r, z, symmetric, ctrs);
       TOCK(t5); // Preconditioner apply time
       test_data.numOfMGCalls++;
       t7 += z.time1_; t8 += z.time2_; t9 += z.time3_; t10 += z.time4_;
@@ -455,15 +487,21 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
       // mixed-precision
       TICK(); ComputeWAXPBY_opt(nrow, one_hi, x_hi, one, z, x_hi, A.isWaxpbyOptimized);
       flops += (itwo*Nrow); TOCK(t11); // x += z
+      ctrs.vecupd.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
+      ctrs.vecupd.add_memory_traffic<scalar_type2>(A.totalNumberOfRows);
 #endif
     } else {
-      // mixed-precision
+      // mixed-precision x += Q*t
       ComputeGEMV (nrow, k-1, one_hi, Q, t, one_hi, x_hi, A.isGemvOptimized);
-      flops += (itwo*Nrow*(k-ione)); // x += Q*t
+      flops += (itwo*Nrow*(k-ione));
+      ctrs.ortho.add_memory_traffic<scalar_type2>(A.totalNumberOfRows*restart_length);
+      ctrs.ortho.add_memory_traffic<scalar_type>(2*A.totalNumberOfRows);
+      ctrs.ortho.add_memory_traffic<project_type>(restart_length);
     }
 
-    flops_gmg += mgft.flops[0];
   } // end of outer-loop
+    
+  //const double flops_gmg = ctrs.mg_gs.get_total_flops() + ctrs.mg_rp.get_total_flops();
 
 
   // Store times
@@ -475,8 +513,8 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
   test_data.times[4]  += t3;       // SPMV time
   test_data.times[5]  += t4;       // AllReduce time
   test_data.times[6]  += t5;       // preconditioner apply time
-  test_data.times[7]  += t7;       // > SpTRSV for GS
-  test_data.times[8]  += t8;       // > SpMV for GS
+  test_data.times[7]  += t7;       // > SpMV for GS (stays 0 for optimized code)
+  test_data.times[8]  += t8;       // > GS
   test_data.times[9]  += t9;       // > Restrict for MG
   test_data.times[10] += t10;      // > Prolong for MG
   test_data.times[11] += t11;      // Vector update time
@@ -485,14 +523,16 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
   test_data.times_comm[1] += t1_comm; // dot-product time
   test_data.times_comm[2] += t3_1;     // > SPMV local copy
   test_data.times_comm[3] += t3_2;     // > SPMV halo exchange
-  const double flops_tot = flops + flops_gmg + flops_spmv + flops_orth;
+  //const double flops_tot = flops + flops_gmg + flops_spmv + flops_orth;
+  // MG flops will be added later in BenchGMRES from test_data.ctrs_bench.
+  const double flops_tot = flops + flops_spmv + flops_orth;
   if (verbose && A.geom->rank==0) {
     HPGMP_fout << " > nnz(A)  : " << A.totalNumberOfNonzeros << std::endl;
     HPGMP_fout << " > nnz(MG) : " << A.totalNumberOfMGNonzeros << " (" << numSpMVs_MG << ")" << std::endl;
     HPGMP_fout << " > SpMV : " << (flops_spmv / 1000000000.0) << " / " << t3 << " = "
                                << (flops_spmv / 1000000000.0) / t3 << " Gflop/s" << std::endl;
-    HPGMP_fout << " > GMG  : " << (flops_gmg  / 1000000000.0) << " / " << t5 << " = "
-                               << (flops_gmg  / 1000000000.0) / t5 << " Gflop/s" << std::endl;
+    //HPGMP_fout << " > GMG  : " << (flops_gmg  / 1000000000.0) << " / " << t5 << " = "
+    //                           << (flops_gmg  / 1000000000.0) / t5 << " Gflop/s" << std::endl;
     HPGMP_fout << " > Orth : " << (flops_orth / 1000000000.0) << " / " << t6 << " = "
                                << (flops_orth / 1000000000.0) / t6 << " Gflop/s" << std::endl;
     HPGMP_fout << " > Total: " << (flops_tot  / 1000000000.0) << " / " << tt << " = "
@@ -500,11 +540,10 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
     HPGMP_fout << std::endl;
   }
   test_data.flops[0] += flops_tot;
-  test_data.flops[1] += flops_gmg;
+  //test_data.flops[1] += flops_gmg;
   test_data.flops[2] += flops_spmv;
   test_data.flops[3] += flops_orth;
 
-  //return ((converged && !IS_NAN(normr)) ? 0 : 1);
   if(!converged) {
       HPGMP_fout << "GMRES-IR did not converge!\n";
       return 1;

--- a/src/ReportResults.cpp
+++ b/src/ReportResults.cpp
@@ -311,6 +311,33 @@ void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
       doc.get("Floating Point Operations Summary")->add(" - Raw MG    (reference)",test_data.ref_flops[1]);
       doc.get("Floating Point Operations Summary")->add(" - Raw Total (reference)",test_data.refTotalFlops);
     }
+    
+    const std::string memtrstr = "Memory Traffic (GB)";
+    doc.add(memtrstr,"");
+    const perf_counters& c_opt = test_data.ctrs_bench;
+    const double optMGBytes = c_opt.mg_rp.get_total_memory_bytes()
+                            + c_opt.mg_gs.get_total_memory_bytes();
+    if (test_data.refTotalTime > 0.0) {
+      doc.get(memtrstr)->add(" - Raw Ortho  (mxp)",c_opt.ortho.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" - Raw SpMV   (mxp)",c_opt.spmv.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" - Raw MG     (mxp)",optMGBytes/1.0e9);
+      doc.get(memtrstr)->add(" -   GS       (mxp)",c_opt.mg_gs.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" -   RestrPro (mxp)",c_opt.mg_rp.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" - Raw vecupd (mxp)",c_opt.vecupd.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" - Raw QRhost (mxp)",c_opt.qr_host.get_total_memory_bytes()/1.0e9);
+    }
+    const perf_counters& c_ref = test_data.ctrs_ref;
+    const double refMGBytes = c_ref.mg_rp.get_total_memory_bytes()
+                            + c_ref.mg_gs.get_total_memory_bytes();
+    if (test_data.refTotalTime > 0.0) {
+      doc.get(memtrstr)->add(" - Raw Ortho  (reference)",c_ref.ortho.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" - Raw SpMV   (reference)",c_ref.spmv.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" - Raw MG     (reference)",refMGBytes/1.0e9);
+      doc.get(memtrstr)->add(" -   GS       (reference)",c_ref.mg_gs.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" -   RestrPro (reference)",c_ref.mg_rp.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" - Raw vecupd (reference)",c_ref.vecupd.get_total_memory_bytes()/1.0e9);
+      doc.get(memtrstr)->add(" - Raw QRhost (reference)",c_ref.qr_host.get_total_memory_bytes()/1.0e9);
+    }
 
 #if 0
     doc.add("GB/s Summary","");
@@ -319,6 +346,52 @@ void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
     doc.get("GB/s Summary")->add("Raw Total B/W",(fnreads+fnwrites)/(times[0])/1.0E9);
     doc.get("GB/s Summary")->add("Total with convergence and optimization phase overhead",(frefnreads+frefnwrites)/(times[0]+(times[7]/10.0+times[9]/10.0))/1.0E9);
 #endif
+    
+    // This final GFLOP/s rating includes the overhead of problem setup
+    //   and optimizing the data structures vs ten sets of 50 iterations
+    const double iter_ratio = ((double)test_data.optNumIters) / ((double)test_data.refNumIters);
+    const double penalGflops = iter_ratio < 1.0 ? 1.0 : iter_ratio;
+
+    const std::string membwstr = "Memory Bandwidth (GB/s)";
+    doc.add(membwstr,"");
+    const double optTotalBytes = (c_opt.ortho.get_total_memory_bytes()
+                  + c_opt.spmv.get_total_memory_bytes() + c_opt.mg_gs.get_total_memory_bytes()
+                  + c_opt.mg_rp.get_total_memory_bytes() + c_opt.vecupd.get_total_memory_bytes()
+                  + c_opt.qr_host.get_total_memory_bytes());
+    doc.get(membwstr)->add(" - Raw Ortho  (mxp)", c_opt.ortho.get_total_memory_bytes()
+                                                           /test_data.opt_times[3]/1.0e9);
+    doc.get(membwstr)->add(" - Raw SpMV   (mxp)", c_opt.spmv.get_total_memory_bytes()
+                                                           /test_data.opt_times[4]/1.0e9);
+    doc.get(membwstr)->add(" - Raw MG     (mxp)", optMGBytes/test_data.opt_times[6]/1.0e9);
+    doc.get(membwstr)->add(" -   GS       (mxp)", c_opt.mg_gs.get_total_memory_bytes()
+                                                           /test_data.opt_times[8]/1.0e9);
+    doc.get(membwstr)->add(" -   RestrPro (mxp)", c_opt.mg_rp.get_total_memory_bytes() /
+                                  (test_data.opt_times[9]+test_data.opt_times[10]) / 1.0e9);
+    doc.get(membwstr)->add(" - Raw vecupd (mxp)", c_opt.vecupd.get_total_memory_bytes() /
+                                                       test_data.opt_times[11]/1.0e9);
+    //doc.get(membwstr)->add(" - Raw QRhost (mxp)", c_opt.qr_host.get_total_memory_bytes()/1.0e9);
+    doc.get(membwstr)->add(" - Raw Total  (mxp)", optTotalBytes / test_data.opt_times[0] / 1.0e9);
+
+    const double refTotalBytes = (c_ref.ortho.get_total_memory_bytes()
+                  + c_ref.spmv.get_total_memory_bytes() + c_ref.mg_gs.get_total_memory_bytes()
+                  + c_ref.mg_rp.get_total_memory_bytes() + c_ref.vecupd.get_total_memory_bytes()
+                  + c_ref.qr_host.get_total_memory_bytes());
+    if (test_data.refTotalTime > 0.0) {
+      doc.get(membwstr)->add(" - Raw Ortho  (reference)",c_ref.ortho.get_total_memory_bytes()
+                                                             /test_data.ref_times[3]/1.0e9);
+      doc.get(membwstr)->add(" - Raw SpMV   (reference)",c_ref.spmv.get_total_memory_bytes()
+                                                             /test_data.ref_times[4]/1.0e9);
+      doc.get(membwstr)->add(" - Raw MG     (reference)",refMGBytes/test_data.ref_times[6]/1.0e9);
+      doc.get(membwstr)->add(" -   GS       (reference)",c_ref.mg_gs.get_total_memory_bytes()
+                                                             /test_data.ref_times[8]/1.0e9);
+      doc.get(membwstr)->add(" -   RestrPro (reference)",c_ref.mg_rp.get_total_memory_bytes() /
+                                    (test_data.ref_times[9]+test_data.ref_times[10]) / 1.0e9);
+      doc.get(membwstr)->add(" - Raw vecupd (reference)",c_ref.vecupd.get_total_memory_bytes() /
+                                                         test_data.ref_times[11]/1.0e9);
+      //doc.get(membwstr)->add(" - Raw QRhost (reference)",c_ref.qr_host.get_total_memory_bytes()/1.0e9);
+      doc.get(membwstr)->add(" - Raw Total  (reference)",refTotalBytes / test_data.refTotalTime / 1.0e9);
+    }
+    doc.get(membwstr)->add("Total for benchmark", optTotalBytes / test_data.opt_times[0] / 1e9 / penalGflops);
 
     doc.add("GFLOP/s Summary","");
     doc.get("GFLOP/s Summary")->add("Raw Orho", test_data.opt_flops[3]/test_data.opt_times[3]/1.0E9);
@@ -331,11 +404,6 @@ void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
       doc.get("GFLOP/s Summary")->add(" - Raw MG    (reference)",test_data.ref_flops[1]/test_data.ref_times[6]/1.0E9);
       doc.get("GFLOP/s Summary")->add(" - Raw Total (reference)",test_data.ref_flops[0]/test_data.ref_times[0]/1.0E9);
       doc.get("GFLOP/s Summary")->add(" - Total     (reference)",test_data.refTotalFlops/test_data.refTotalTime/1.0E9);
-    }
-    // This final GFLOP/s rating includes the overhead of problem setup and optimizing the data structures vs ten sets of 50 iterations of CG
-    double penalGflops = ((double)test_data.optNumIters) / ((double)test_data.refNumIters);
-    if (penalGflops < 1.0) {
-      penalGflops = 1.0;
     }
     double totalGflops = (test_data.opt_flops[0]/test_data.opt_times[0]/1.0E9) / penalGflops;
     doc.get("GFLOP/s Summary")->add("Total for benchmark",totalGflops);

--- a/src/hpgmp.hpp
+++ b/src/hpgmp.hpp
@@ -109,19 +109,6 @@ int HPGMP_Init_Params(int * argc_p, char ** *argv_p, HPGMP_Params & params, comm
 int HPGMP_Init(int * argc_p, char ** *argv_p);
 int HPGMP_Finalize(void);
 
-/** Stores the number of floating point operations (flops) and
- * loads and stores from memory (mem_traffic) in any kernel.
- *
- * Stores flops and memory traffic separately for every precision used,
- * stored highest precision to lowest precision.
- */
-struct flops_and_traffic {
-    static constexpr int n_precs = 2;
-    std::array<double, n_precs> flops;
-    std::array<double, n_precs> f_mem_traffic;
-    double i_mem_traffic;
-};
-
 #define IS_NAN(a) (std::isinf(a) || std::isnan(a) || !(a == a))
 
 #ifdef HPGMP_VERBOSE

--- a/src/perf_counter.hpp
+++ b/src/perf_counter.hpp
@@ -1,0 +1,128 @@
+#ifndef HPGMP_PERF_COUNTER_HPP
+#define HPGMP_PERF_COUNTER_HPP
+
+#include "DataTypes.hpp"
+
+/** Stores the number of floating point operations (flops) and
+ * loads and stores from memory (mem_traffic) in any kernel.
+ *
+ * Stores flops and memory traffic separately for every precision used,
+ * stored highest precision to lowest precision.
+ */
+class flops_and_traffic {
+public: 
+    static constexpr int n_precs = 2;
+
+    /// Get index in counter arrays based on precision type. 
+    template <typename T> 
+    constexpr std::enable_if_t<std::is_floating_point<T>::value, int> index() const
+    {
+        if constexpr (std::is_same<T, double>::value) {
+            return 0;
+        } else if constexpr (std::is_same<T,float>::value) {
+            return 1;
+        } else if constexpr (std::is_same<T,half>::value) {
+            return 2;
+        } else {
+            static_assert(false, "Precision not supported!");
+        }
+    }
+
+    template <typename T> 
+    std::enable_if_t<std::is_floating_point<T>::value> add_flops(const double count)
+    {
+        constexpr int idx = index<T>();
+        flops[idx] += count;
+    }
+
+    template <typename T> 
+    std::enable_if_t<std::is_floating_point<T>::value, double> get_flops() const
+    {
+        constexpr int idx = index<T>();
+        return flops[idx];
+    }
+
+    double get_total_flops() const
+    {
+        double total = 0;
+        for (auto x : flops) {
+            total += x;
+        }
+        return total;
+    }
+
+    template <typename T> 
+    std::enable_if_t<std::is_floating_point<T>::value> add_memory_traffic(const double count)
+    {
+        constexpr int idx = index<T>();
+        f_mem_traffic[idx] += count;
+    }
+
+    template <typename T>
+    std::enable_if_t<std::is_same<T,int>::value> add_memory_traffic(const double count)
+    {
+        i_mem_traffic += count;
+    }
+
+    template <typename T> 
+    std::enable_if_t<std::is_floating_point<T>::value, double> get_memory_traffic() const
+    {
+        constexpr int idx = index<T>();
+        return f_mem_traffic[idx];
+    }
+
+    template <typename T>
+    std::enable_if_t<std::is_same<T,int>::value, double> get_memory_traffic() const
+    {
+        return i_mem_traffic;
+    }
+
+    double get_total_memory_bytes() const
+    {
+        double total = i_mem_traffic * sizeof(int);
+        constexpr std::array<size_t,3> sizes{sizeof(double), sizeof(float), sizeof(half)};
+        for(int i = 0; i < n_precs; i++) {
+            total += static_cast<double>(f_mem_traffic[i])*sizes[i];
+        }
+        return total;
+    }
+
+    void reset() {
+        flops = {};
+        f_mem_traffic = {};
+        i_mem_traffic = {};
+        //i_mem_traffic = 0.0;
+        //for(int i = 0; i < n_precs; i++) {
+        //    flops[i] =0.0;
+        //    f_mem_traffic[i] = 0.0;
+        //}
+    }
+
+private:
+    std::array<double, n_precs> flops = {};
+    std::array<double, n_precs> f_mem_traffic = {};
+    double i_mem_traffic{};
+};
+
+/** Floating-point operations and memory traffic counters for different parts of HPGMP.
+ */
+struct perf_counters {
+    flops_and_traffic mg_gs;    ///< Gauss-Seidel
+    flops_and_traffic mg_rp;    ///< Restriction (-SpMV fused) and prolongation
+    flops_and_traffic ortho;    ///< CGS2 orthogonalization
+    flops_and_traffic spmv;     ///< SpMV outside MG
+    flops_and_traffic vecupd;   ///< Vector update operations WAXPBY and scale
+    flops_and_traffic qr_host;  ///< QR factorization update on host
+
+    /// Reset all counters to zero
+    void reset() {
+        mg_gs.reset();
+        mg_rp.reset();
+        ortho.reset();
+        spmv.reset();
+        vecupd.reset();
+        qr_host.reset();
+    }
+};
+
+#endif


### PR DESCRIPTION
This PR adds a `perf_counters` class to handle accumulation of flops and bytes and various types. For now, this is only used for the multigrid (MG) preconditioner. The code now also output estimated memory bandwidth information, using a simple model that accumulates a certain amount of memory traffic for every kernel call. Cache effects are ignored.