### PR TITLE
ROCTX and NVTX profiling annotations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,13 +232,6 @@ if (HPGMP_ENABLE_CUDA)
     target_link_libraries(hpgmp_device PUBLIC CUDA::cublas CUDA::cusparse CUDA::curand)
     target_link_libraries(hpgmp PUBLIC
                           CUDA::cublas CUDA::cusparse CUDA::curand)
-
-    if(HPGMP_ENABLE_PROFILING)
-      target_compile_definitions(hpgmp PUBLIC HPGMP_WITH_PROFILING)
-      target_link_libraries(hpgmp PUBLIC
-        CUDA::nvToolsExt
-      )
-    endif()
 else ()
     target_compile_definitions(hpgmp PUBLIC HPGMP_NO_CUDA)
 endif ()
@@ -251,25 +244,27 @@ if (HPGMP_ENABLE_HIP)
     target_link_libraries(hpgmp_device PRIVATE roc::rocprim)
     target_link_libraries(hpgmp PUBLIC hip::host roc::rocrand)
     target_link_libraries(hpgmp PUBLIC roc::rocblas roc::rocsparse)
-
-    if(HPGMP_ENABLE_PROFILING)
-      target_compile_definitions(hpgmp PUBLIC HPGMP_WITH_PROFILING)
-      target_include_directories(hpgmp PUBLIC 
-        ${ROCM_PATH}/include)
-      target_link_libraries(hpgmp PUBLIC
-        "-L${ROCM_PATH}/lib -lroctx64 -lroctracer64" 
-      )
-      target_compile_definitions(hpgmp_device PUBLIC HPGMP_WITH_PROFILING)
-      target_include_directories(hpgmp_device PUBLIC 
-        ${ROCM_PATH}/include)
-      target_link_libraries(hpgmp_device PUBLIC
-        "-L${ROCM_PATH}/lib -lroctx64 -lroctracer64" 
-      )
-    endif()
 else ()
     target_compile_definitions(hpgmp PUBLIC HPGMP_NO_HIP)
 endif ()
 
+if(HPGMP_ENABLE_PROFILING)
+    target_compile_definitions(hpgmp PUBLIC HPGMP_WITH_PROFILING)
+
+    if (HPGMP_ENABLE_CUDA)
+        target_compile_definitions(hpgmp_device PUBLIC HPGMP_WITH_PROFILING)
+        target_link_libraries(hpgmp_device PUBLIC
+          CUDA::nvToolsExt
+        )
+    endif()
+
+    if (HPGMP_ENABLE_HIP)
+        target_compile_definitions(hpgmp_device PUBLIC HPGMP_WITH_PROFILING)
+        target_link_libraries(hpgmp_device PUBLIC
+          "-L${ROCM_PATH}/lib -lroctx64 -lroctracer64" 
+        )
+    endif()
+endif()
 
 if (HPGMP_ENABLE_BLAS)
     target_compile_definitions(hpgmp PUBLIC HPGMP_WITH_BLAS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(HPGMP_ENABLE_HIP "Enable HIP support" OFF)
 option(HPGMP_ENABLE_TESTS "Enable unit tests" ON)
 option(HPGMP_BUILD_REFERENCE "Build reference implementation without optimizations" OFF)
 option(HPGMP_ENABLE_ASAN "Build address sanitizer" OFF)
+option(HPGMP_ENABLE_PROFILING "Enable profiling" OFF)
 option(CMAKE_DEBUG "Enable CMake script debugging" OFF)
 
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result")
@@ -231,6 +232,13 @@ if (HPGMP_ENABLE_CUDA)
     target_link_libraries(hpgmp_device PUBLIC CUDA::cublas CUDA::cusparse CUDA::curand)
     target_link_libraries(hpgmp PUBLIC
                           CUDA::cublas CUDA::cusparse CUDA::curand)
+
+    if(HPGMP_ENABLE_PROFILING)
+      target_compile_definitions(hpgmp PUBLIC HPGMP_WITH_PROFILING)
+      target_link_libraries(hpgmp PUBLIC
+        CUDA::nvToolsExt
+      )
+    endif()
 else ()
     target_compile_definitions(hpgmp PUBLIC HPGMP_NO_CUDA)
 endif ()
@@ -243,6 +251,21 @@ if (HPGMP_ENABLE_HIP)
     target_link_libraries(hpgmp_device PRIVATE roc::rocprim)
     target_link_libraries(hpgmp PUBLIC hip::host roc::rocrand)
     target_link_libraries(hpgmp PUBLIC roc::rocblas roc::rocsparse)
+
+    if(HPGMP_ENABLE_PROFILING)
+      target_compile_definitions(hpgmp PUBLIC HPGMP_WITH_PROFILING)
+      target_include_directories(hpgmp PUBLIC 
+        ${ROCM_PATH}/include)
+      target_link_libraries(hpgmp PUBLIC
+        "-L${ROCM_PATH}/lib -lroctx64 -lroctracer64" 
+      )
+      target_compile_definitions(hpgmp_device PUBLIC HPGMP_WITH_PROFILING)
+      target_include_directories(hpgmp_device PUBLIC 
+        ${ROCM_PATH}/include)
+      target_link_libraries(hpgmp_device PUBLIC
+        "-L${ROCM_PATH}/lib -lroctx64 -lroctracer64" 
+      )
+    endif()
 else ()
     target_compile_definitions(hpgmp PUBLIC HPGMP_NO_HIP)
 endif ()

--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -68,6 +68,7 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
                bool verbose, bool runReference, const bool validation_failure,
                TestGMRESDataType & test_data)
 {
+  HPGMP_RANGE_PUSH(__FUNCTION__);
   typedef Vector<scalar_type> Vector_type;
   typedef SparseMatrix<scalar_type> SparseMatrix_type;
   typedef GMRESData<scalar_type> GMRESData_type;
@@ -106,7 +107,11 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
   }
   // =====================================================================
   // Benchmark parameters
+#ifdef HPGMP_WITH_PROFILING
+  const int maxIters = 1; // Will perform at least restart_length
+#else
   const int maxIters = 300;
+#endif
   // Any official benchmark result must run at least this many seconds
   //double minOfficialTime = 1800;
   const double minOfficialTime = 120; // for testing..
@@ -141,6 +146,9 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
       HPGMP_fout << "Warm-up runs" << endl;
     }
 
+#ifdef HPGMP_WITH_PROFILING
+    const int numberOfGmresCalls = 1;
+#else // HPGMP_WITH_PROFILING
     const int timing_calls = 10;
     double gmresir_run_time = 0;
     
@@ -176,6 +184,7 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
     const int numberOfGmresCalls = test_data.runningTime >= 0.0 ?
         ceil(test_data.runningTime / avg_run_time) :
         ceil(test_data.minOfficialTime / avg_run_time);
+#endif // HPGMP_WITH_PROFILING
     if (A.geom->rank==0) {
         std::cout << "Number of benchmarking GMRES runs will be " << numberOfGmresCalls
                   << std::endl;
@@ -271,7 +280,11 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
   // Run reference GMRES implementation for a fixed number of iterations
   // and record the obtained Gflop/s
   if (runReference) {
+#ifdef HPGMP_WITH_PROFILING
+    const int n_ref_calls = 1;
+#else
     const int n_ref_calls = 10;
+#endif
     x.fill_zero();
     //warmup
     GMRES(A, data, b, x, restart_length, maxIters, tolerance, niters, normr, normr0, precond,
@@ -377,6 +390,7 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
   }
 
   delete geom;
+  HPGMP_RANGE_POP(__FUNCTION__);
   return 0;
 }
 

--- a/src/ComputeDotProduct_blas.cpp
+++ b/src/ComputeDotProduct_blas.cpp
@@ -22,9 +22,9 @@
 #if defined(HPGMP_WITH_BLAS)
 
 #include "cblas.h"
+#include "mytimer.hpp"
 #ifndef HPGMP_NO_MPI
  #include <mpi.h>
- #include "mytimer.hpp"
  #include "Utils_MPI.hpp"
 #endif
 #include "ComputeDotProduct_ref.hpp"
@@ -53,6 +53,9 @@
 template<class Vector_type, class scalar_type>
 int ComputeDotProduct_ref(const local_int_t n, const Vector_type & x, const Vector_type & y,
                           scalar_type & result, double & time_allreduce) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   assert(x.localLength>=n); // Test vector lengths
   assert(y.localLength>=n);
 
@@ -81,6 +84,8 @@ int ComputeDotProduct_ref(const local_int_t n, const Vector_type & x, const Vect
   time_allreduce += 0.0;
   result = local_result;
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeDotProduct_gpu.cpp
+++ b/src/ComputeDotProduct_gpu.cpp
@@ -26,9 +26,9 @@
 #endif
 #include <cassert>
 
+#include "mytimer.hpp"
 #ifndef HPGMP_NO_MPI
  #include <mpi.h>
- #include "mytimer.hpp"
  #include "Utils_MPI.hpp"
 #endif
 
@@ -55,6 +55,9 @@
 template<class Vector_type, class output_scalar_type>
 int ComputeDotProduct_ref(const local_int_t n, const Vector_type & x, const Vector_type & y,
                           output_scalar_type & result, double & time_allreduce) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   assert(x.local_length()>=n); // Test vector lengths
   assert(y.local_length()>=n);
 
@@ -142,6 +145,8 @@ int ComputeDotProduct_ref(const local_int_t n, const Vector_type & x, const Vect
   time_allreduce += 0.0;
   result = local_result;
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeDotProduct_ref.cpp
+++ b/src/ComputeDotProduct_ref.cpp
@@ -21,9 +21,9 @@
  */
 #if !defined(HPGMP_WITH_BLAS) & !defined(HPGMP_WITH_CUDA) & !defined(HPGMP_WITH_HIP)
 
+#include "mytimer.hpp"
 #ifndef HPGMP_NO_MPI
  #include <mpi.h>
- #include "mytimer.hpp"
  #include "Utils_MPI.hpp"
 #endif
 #include "ComputeDotProduct_ref.hpp"
@@ -52,6 +52,9 @@
 template<class Vector_type, class scalar_type>
 int ComputeDotProduct_ref(const local_int_t n, const Vector_type & x, const Vector_type & y,
                           scalar_type & result, double & time_allreduce) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   assert(x.localLength>=n); // Test vector lengths
   assert(y.localLength>=n);
 
@@ -86,6 +89,8 @@ int ComputeDotProduct_ref(const local_int_t n, const Vector_type & x, const Vect
 #else
   time_allreduce += 0.0;
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeGEMMT_gpu.cpp
+++ b/src/ComputeGEMMT_gpu.cpp
@@ -35,6 +35,8 @@ int ComputeGEMMT_ref(const local_int_t m, const local_int_t n, const local_int_t
                      const typename MultiVector_type::scalar_type alpha, const MultiVector_type & A, const MultiVector_type & B,
                      const typename SerialDenseMatrix_type::scalar_type beta, SerialDenseMatrix_type & C) {
 
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   typedef typename       MultiVector_type::scalar_type scalarA_type;
   typedef typename SerialDenseMatrix_type::scalar_type scalarC_type;
 
@@ -111,6 +113,8 @@ int ComputeGEMMT_ref(const local_int_t m, const local_int_t n, const local_int_t
 #else
   C.time2 = 0.0;
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeGEMMT_ref.cpp
+++ b/src/ComputeGEMMT_ref.cpp
@@ -34,6 +34,8 @@ int ComputeGEMMT_ref(const local_int_t m, const local_int_t n, const local_int_t
                      const typename MultiVector_type::scalar_type alpha, const MultiVector_type & A, const MultiVector_type & B,
                      const typename SerialDenseMatrix_type::scalar_type beta, SerialDenseMatrix_type & C) {
 
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   typedef typename       MultiVector_type::scalar_type scalarA_type;
   typedef typename SerialDenseMatrix_type::scalar_type scalarC_type;
 
@@ -85,6 +87,8 @@ int ComputeGEMMT_ref(const local_int_t m, const local_int_t n, const local_int_t
 #else
   C.time2 = 0.0;
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeGEMVT_blas.cpp
+++ b/src/ComputeGEMVT_blas.cpp
@@ -36,6 +36,8 @@ int ComputeGEMVT_ref(const local_int_t m, const local_int_t n,
                      const typename MultiVector_type::scalar_type alpha, const MultiVector_type & A, const Vector_type & x,
                      const typename SerialDenseMatrix_type::scalar_type beta, SerialDenseMatrix_type & y) {
 
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   typedef typename       MultiVector_type::scalar_type scalarA_type;
   typedef typename SerialDenseMatrix_type::scalar_type scalarX_type;
   typedef typename            Vector_type::scalar_type scalarY_type;
@@ -77,6 +79,8 @@ int ComputeGEMVT_ref(const local_int_t m, const local_int_t n,
 #else
   y.time2 = 0.0;
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeGEMVT_gpu.cpp
+++ b/src/ComputeGEMVT_gpu.cpp
@@ -35,6 +35,8 @@ int ComputeGEMVT_ref(const local_int_t m, const local_int_t n,
                      const typename MultiVector_type::scalar_type alpha, const MultiVector_type & A, const Vector_type & x,
                      const typename SerialDenseMatrix_type::scalar_type beta, SerialDenseMatrix_type & y) {
 
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   typedef typename       MultiVector_type::scalar_type scalarA_type;
   typedef typename            Vector_type::scalar_type scalarX_type;
   typedef typename SerialDenseMatrix_type::scalar_type scalarY_type;
@@ -144,6 +146,8 @@ int ComputeGEMVT_ref(const local_int_t m, const local_int_t n,
 #else
   y.time2 = 0.0;
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeGEMVT_ref.cpp
+++ b/src/ComputeGEMVT_ref.cpp
@@ -34,6 +34,8 @@ int ComputeGEMVT_ref(const local_int_t m, const local_int_t n,
                      const typename MultiVector_type::scalar_type alpha, const MultiVector_type & A, const Vector_type & x,
                      const typename SerialDenseMatrix_type::scalar_type beta, SerialDenseMatrix_type & y) {
 
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   typedef typename       MultiVector_type::scalar_type scalarA_type;
   typedef typename SerialDenseMatrix_type::scalar_type scalarX_type;
   typedef typename            Vector_type::scalar_type scalarY_type;
@@ -84,6 +86,8 @@ int ComputeGEMVT_ref(const local_int_t m, const local_int_t n,
 #else
   y.time2 = 0.0;
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeGEMV_blas.cpp
+++ b/src/ComputeGEMV_blas.cpp
@@ -24,7 +24,7 @@
 #include "cblas.h"
 #include "ComputeGEMV_ref.hpp"
 #include "hpgmp.hpp"
-#include "Profiling"
+#include "Profiling.hpp"
 
 template<class MultiVector_type, class Vector_type, class SerialDenseMatrix_type>
 int ComputeGEMV_ref(const local_int_t m, const local_int_t n,

--- a/src/ComputeGEMV_blas.cpp
+++ b/src/ComputeGEMV_blas.cpp
@@ -24,11 +24,14 @@
 #include "cblas.h"
 #include "ComputeGEMV_ref.hpp"
 #include "hpgmp.hpp"
+#include "Profiling"
 
 template<class MultiVector_type, class Vector_type, class SerialDenseMatrix_type>
 int ComputeGEMV_ref(const local_int_t m, const local_int_t n,
                     const typename MultiVector_type::scalar_type alpha, const MultiVector_type & A, const SerialDenseMatrix_type & x,
                     const typename      Vector_type::scalar_type beta,  const Vector_type & y) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
 
   typedef typename       MultiVector_type::scalar_type scalarA_type;
   typedef typename SerialDenseMatrix_type::scalar_type scalarX_type;
@@ -85,6 +88,8 @@ int ComputeGEMV_ref(const local_int_t m, const local_int_t n,
       }
     }
   }
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeGEMV_gpu.cpp
+++ b/src/ComputeGEMV_gpu.cpp
@@ -24,11 +24,14 @@
 #include "ComputeGEMV_ref.hpp"
 #include "hpgmp.hpp"
 #include "DataTypes.hpp"
+#include "Profiling.hpp"
 
 template<class MultiVector_type, class Vector_type, class SerialDenseMatrix_type>
 int ComputeGEMV_ref(const local_int_t m, const local_int_t n,
                     const typename MultiVector_type::scalar_type alpha, const MultiVector_type & A, const SerialDenseMatrix_type & x,
                     const typename      Vector_type::scalar_type beta,  Vector_type & y) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
 
   typedef typename       MultiVector_type::scalar_type scalarA_type;
   typedef typename SerialDenseMatrix_type::scalar_type scalarX_type;
@@ -148,6 +151,9 @@ int ComputeGEMV_ref(const local_int_t m, const local_int_t n,
 
     y.update_device_data();
   }
+
+  HPGMP_RANGE_POP(__FUNCTION__);
+
   return 0;
 }
 

--- a/src/ComputeGEMV_ref.cpp
+++ b/src/ComputeGEMV_ref.cpp
@@ -23,11 +23,14 @@
 
 #include "ComputeGEMV_ref.hpp"
 #include "hpgmp.hpp"
+#include "Profiling.hpp"
 
 template<class MultiVector_type, class Vector_type, class SerialDenseMatrix_type>
 int ComputeGEMV_ref(const local_int_t m, const local_int_t n,
                     const typename MultiVector_type::scalar_type alpha, const MultiVector_type & A, const SerialDenseMatrix_type & x,
                     const typename      Vector_type::scalar_type beta,  Vector_type & y) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
 
   typedef typename       MultiVector_type::scalar_type scalarA_type;
   typedef typename SerialDenseMatrix_type::scalar_type scalarX_type;
@@ -64,6 +67,8 @@ int ComputeGEMV_ref(const local_int_t m, const local_int_t n,
         yv[i] += alpha * Av[i + j*m] * xv[j];
     }
   }
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeGS_Forward_gpu.cpp
+++ b/src/ComputeGS_Forward_gpu.cpp
@@ -64,6 +64,8 @@
 template<class SparseMatrix_type, class Vector_type>
 int ComputeGS_Forward_ref(const SparseMatrix_type & A, const Vector_type & r, Vector_type & x) {
 
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   assert(x.local_length()==A.localNumberOfColumns); // Make sure x contain space for halo values
 
   typedef typename SparseMatrix_type::scalar_type scalar_type;
@@ -315,6 +317,8 @@ int ComputeGS_Forward_ref(const SparseMatrix_type & A, const Vector_type & r, Ve
   }
   free(tv);
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeGS_Forward_ref.cpp
+++ b/src/ComputeGS_Forward_ref.cpp
@@ -54,6 +54,8 @@
 template<class SparseMatrix_type, class Vector_type>
 int ComputeGS_Forward_ref(const SparseMatrix_type & A, const Vector_type & r, Vector_type & x) {
 
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   assert(x.localLength==A.localNumberOfColumns); // Make sure x contain space for halo values
 
   typedef typename SparseMatrix_type::scalar_type scalar_type;
@@ -87,6 +89,8 @@ int ComputeGS_Forward_ref(const SparseMatrix_type & A, const Vector_type & r, Ve
     xv[i] = sum/currentDiagonal;
   }
   TOCK(x.time2);
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeMG.cpp
+++ b/src/ComputeMG.cpp
@@ -51,6 +51,9 @@ template<class SparseMatrix_type, class Vector_type>
 int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & x,
               const bool symmetric, perf_counters& ft)
 {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   using scalar_type = typename SparseMatrix_type::scalar_type;
   const int mpisize = A.geom->size;
 
@@ -71,6 +74,9 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     // Intentional abuse of Vector class timing variables
     auto time_gs_sofar = x.time2_;
     x.time2_ = 0.0;
+
+    HPGMP_RANGE_PUSH("ell_multicolor_gs");
+
     TICK();
 
     for(int i=0; i < numberOfPresmootherSteps; ++i) {
@@ -96,10 +102,14 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     x.time2_ = time_gs_sofar;
     TOCK(x.time2_);
 
-    if (ierr!=0)
+    HPGMP_RANGE_POP("ell_multicolor_gs");
+    if (ierr!=0) {
+        HPGMP_RANGE_POP(__FUNCTION__);
         return ierr;
+    }
 
     // Restriction operation
+    HPGMP_RANGE_PUSH("fused_spmv_restriction");
     TICK();
     //ierr = restriction(A, r);
     ierr = fused_spmv_restriction(A, r, x);
@@ -110,19 +120,25 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     ft.mg_rp.add_memory_traffic<local_int_t>(3*coarse_len + A.Ac->totalNumberOfNonzeros);
     ft.mg_rp.add_memory_traffic<scalar_type>(coarse_len + A.Ac->totalNumberOfNonzeros
                                              + A.totalNumberOfRows);
-    if (ierr!=0)
+    HPGMP_RANGE_POP("fused_spmv_restriction");
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
       return ierr;
+    }
 
     // MG on coarser-grid
     A.mgData->xc->time1_ = A.mgData->xc->time2_ = 0.0;
     A.mgData->xc->time3_ = A.mgData->xc->time4_ = 0.0;
     ierr = ComputeMG(*A.Ac,*A.mgData->rc, *A.mgData->xc, symmetric, ft);
-    if (ierr!=0)
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
       return ierr;
+    }
     x.time1_ += A.mgData->xc->time1_; x.time2_ += A.mgData->xc->time2_;
     x.time3_ += A.mgData->xc->time3_; x.time4_ += A.mgData->xc->time4_;
 
     // Prolongation operation
+    HPGMP_RANGE_PUSH("prolongation");
     TICK();
     ierr = prolongation(A, x);
     TOCK(x.time4_);
@@ -130,12 +146,16 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     ft.mg_rp.add_flops<scalar_type>(coarse_len);
     ft.mg_rp.add_memory_traffic<local_int_t>(coarse_len*3);
     ft.mg_rp.add_memory_traffic<scalar_type>(coarse_len*2);
-    if (ierr!=0)
+    HPGMP_RANGE_POP("prolongation");
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
       return ierr;
+    }
 
     // Post-smoothing
     time_gs_sofar = x.time2_;
     x.time2_ = 0.0;
+    HPGMP_RANGE_PUSH("post-smoothing");
     TICK();
 
     const int numberOfPostsmootherSteps = A.mgData->numberOfPostsmootherSteps;
@@ -150,13 +170,17 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     // restore GS time so far
     x.time2_ = time_gs_sofar;
     TOCK(x.time2_);
-    if (ierr!=0)
+    HPGMP_RANGE_POP("post-smoothing");
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
       return ierr;
+    }
   }
   else {
     // coarsest grid
     auto time_gs_sofar = x.time2_;
     x.time2_ = 0.0;
+    HPGMP_RANGE_PUSH("ell_multicolor_gs");
     TICK();
 
     ierr += ell_multicolor_gs(symmetric, mat.get(), &r, &x);
@@ -165,13 +189,19 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     // restore GS time so far
     x.time2_ = time_gs_sofar;
     TOCK(x.time2_);
+    HPGMP_RANGE_POP("ell_multicolor_gs");
     //ft.mg_gs.flops[0] += 2*A.totalNumberOfNonzeros;
     ft.mg_gs.add_flops<scalar_type>(2*A.totalNumberOfNonzeros);
     ft.mg_gs.add_memory_traffic<scalar_type>(A.totalNumberOfNonzeros + 2*A.totalNumberOfRows);
     ft.mg_gs.add_memory_traffic<local_int_t>(A.totalNumberOfNonzeros);
-    if (ierr!=0)
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
       return ierr;
+    }
   }
+
+  HPGMP_RANGE_POP(__FUNCTION__);
+
   return 0;
 }
 

--- a/src/ComputeMG_ref.cpp
+++ b/src/ComputeMG_ref.cpp
@@ -47,6 +47,9 @@
 */
 template<class SparseMatrix_type, class Vector_type>
 int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & x, bool symmetric) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   assert(x.local_length()==A.localNumberOfColumns); // Make sure x contain space for halo values
 
   // initialize x to zero
@@ -63,8 +66,10 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
       for (int i=0; i< numberOfPresmootherSteps; ++i)
           ierr += ComputeGS_Forward_ref(A, r, x);
     }
-    if (ierr!=0)
-        return ierr;
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
+      return ierr;
+    }
 
     // Compute residual vector
     TICK();
@@ -78,24 +83,30 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     // Restriction operation
     TICK();
     ierr = ComputeRestriction_ref(A, r);
-    if (ierr!=0)
-        return ierr;
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
+      return ierr;
+    }
     TOCK(x.time3);
 
     // MG on coarser-grid
     A.mgData->xc->time1 = A.mgData->xc->time2 = 0.0;
     A.mgData->xc->time3 = A.mgData->xc->time4 = 0.0;
     ierr = ComputeMG_ref(*A.Ac,*A.mgData->rc, *A.mgData->xc, symmetric);
-    if (ierr!=0)
-        return ierr;
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
+      return ierr;
+    }
     x.time1 += A.mgData->xc->time1; x.time2 += A.mgData->xc->time2;
     x.time3 += A.mgData->xc->time3; x.time4 += A.mgData->xc->time4;
 
     // Prolongation operation
     TICK();
     ierr = ComputeProlongation_ref(A, x);
-    if (ierr!=0)
-        return ierr;
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
+      return ierr;
+    }
     TOCK(x.time4);
 
     // Post-smoothing
@@ -107,8 +118,10 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
       for (int i=0; i< numberOfPostsmootherSteps; ++i)
           ierr += ComputeGS_Forward_ref(A, r, x);
     }
-    if (ierr!=0)
-        return ierr;
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
+      return ierr;
+    }
   }
   else {
     // coarsest grid
@@ -117,8 +130,14 @@ int ComputeMG(const SparseMatrix_type & A, const Vector_type & r, Vector_type & 
     } else {
       ierr = ComputeGS_Forward_ref(A, r, x);
     }
-    if (ierr!=0) return ierr;
+    if (ierr!=0) {
+      HPGMP_RANGE_POP(__FUNCTION__);
+      return ierr;
+    }
   }
+
+  HPGMP_RANGE_POP(__FUNCTION__);
+
   return 0;
 }
 

--- a/src/ComputeSPMV_gpu.cpp
+++ b/src/ComputeSPMV_gpu.cpp
@@ -57,6 +57,9 @@
 template<class SparseMatrix_type, class Vector_type>
 int ComputeSPMV_ref(const SparseMatrix_type & A, Vector_type & x, Vector_type & y)
 {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   assert(x.local_length()>=A.localNumberOfColumns); // Test vector lengths
   assert(y.local_length()>=A.localNumberOfRows);
   typedef typename SparseMatrix_type::scalar_type scalar_type;
@@ -109,6 +112,7 @@ int ComputeSPMV_ref(const SparseMatrix_type & A, Vector_type & x, Vector_type & 
     computeType = CUDA_R_32F;
   } else {
     printf( " ComputeSPMV only supported double or float\n" );
+    HPGMP_RANGE_POP(__FUNCTION__);
     return 0;
   }
   // create matrix
@@ -222,6 +226,8 @@ int ComputeSPMV_ref(const SparseMatrix_type & A, Vector_type & x, Vector_type & 
   }
   free(tv);
 #endif
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeSPMV_ref.cpp
+++ b/src/ComputeSPMV_ref.cpp
@@ -49,6 +49,9 @@
 */
 template<class SparseMatrix_type, class Vector_type>
 int ComputeSPMV_ref(const SparseMatrix_type & A, Vector_type & x, Vector_type & y) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   assert(x.localLength>=A.localNumberOfColumns); // Test vector lengths
   assert(y.localLength>=A.localNumberOfRows);
   typedef typename SparseMatrix_type::scalar_type scalar_type;
@@ -76,6 +79,8 @@ int ComputeSPMV_ref(const SparseMatrix_type & A, Vector_type & x, Vector_type & 
       sum += cur_vals[j]*xv[cur_inds[j]];
     yv[i] = sum;
   }
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ComputeWAXPBY_opt.dev.cpp
+++ b/src/ComputeWAXPBY_opt.dev.cpp
@@ -36,6 +36,8 @@
 #include "hpgmp.hpp"
 #include "DataTypes.hpp"
 
+#include "Profiling.hpp"
+
 template <typename x_type, typename y_type, typename w_type>
 __global__
 void waxpby(const local_int_t n, const x_type alpha, const x_type *const __restrict__ xv,
@@ -73,12 +75,18 @@ int ComputeWAXPBY_opt(const local_int_t n,
                             VectorW_type & w,
                       bool& isoptimized)
 {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   isoptimized = true;
   assert(x.local_length()>=n); // Test vector lengths
   assert(y.local_length()>=n);
 
   // quick return
-  if (n <= 0) return 0;
+  if (n <= 0) {
+    HPGMP_RANGE_POP(__FUNCTION__);
+    return 0;
+  }
 
   typedef typename VectorX_type::scalar_type scalarX_type;
   typedef typename VectorY_type::scalar_type scalarY_type;
@@ -150,6 +158,9 @@ int ComputeWAXPBY_opt(const local_int_t n,
       const int nblocks = (n - 1) / threads_per_block + 1;
       waxpby<<<nblocks, threads_per_block, 0, 0>>>(n, alpha, d_xv, beta, d_yv, d_wv);
   }
+
+  HPGMP_RANGE_POP(__FUNCTION__);
+
   return 0;
 }
 

--- a/src/ComputeWAXPBY_ref.cpp
+++ b/src/ComputeWAXPBY_ref.cpp
@@ -29,6 +29,8 @@
  #include <omp.h>
 #endif
 
+#include "Profiling.hpp"
+
 /*!
   Routine to compute the update of a vector with the sum of two
   scaled vectors where: w = alpha*x + beta*y
@@ -52,11 +54,17 @@ int ComputeWAXPBY_ref(const local_int_t n,
                       const typename VectorY_type::scalar_type beta,
                       const VectorY_type & y,
                             VectorW_type & w) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   assert(x.localLength>=n); // Test vector lengths
   assert(y.localLength>=n);
 
   // quick return
-  if (n <= 0) return 0;
+  if (n <= 0) {
+    HPGMP_RANGE_POP(__FUNCTION__);
+    return 0;
+  }
 
   typedef typename VectorX_type::scalar_type scalarX_type;
   typedef typename VectorY_type::scalar_type scalarY_type;
@@ -82,6 +90,8 @@ int ComputeWAXPBY_ref(const local_int_t n,
     #endif
     for (local_int_t i=0; i<n; i++) wv[i] = alpha * xv[i] + beta * yv[i];
   }
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return 0;
 }

--- a/src/ExchangeHalo_gpu.cpp
+++ b/src/ExchangeHalo_gpu.cpp
@@ -48,6 +48,9 @@ __global__ void haloGather(const int totalToBeSent, const scalar *const d_x, sca
 
 template<class SparseMatrix_type, class Vector_type>
 void ExchangeHalo_ref(const SparseMatrix_type & A, Vector_type & x) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   typedef typename SparseMatrix_type::scalar_type scalar_type;
   MPI_Datatype MPI_SCALAR_TYPE = MpiTypeTraits<scalar_type>::getType ();
 
@@ -69,7 +72,10 @@ void ExchangeHalo_ref(const SparseMatrix_type & A, Vector_type & x) {
   int size, rank; // Number of MPI processes, My process ID
   MPI_Comm_size(A.comm, &size);
   MPI_Comm_rank(A.comm, &rank);
-  if (size == 1) return;
+  if (size == 1) {
+    HPGMP_RANGE_POP(__FUNCTION__);
+    return;
+  }
 
   //
   //  first post receives, these are immediate receives
@@ -172,6 +178,8 @@ void ExchangeHalo_ref(const SparseMatrix_type & A, Vector_type & x) {
 
   x.time1 = time1; x.time2 = time2;
   delete [] request;
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return;
 }

--- a/src/ExchangeHalo_ref.cpp
+++ b/src/ExchangeHalo_ref.cpp
@@ -37,6 +37,9 @@
  */
 template<class SparseMatrix_type, class Vector_type>
 void ExchangeHalo_ref(const SparseMatrix_type & A, Vector_type & x) {
+
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   typedef typename SparseMatrix_type::scalar_type scalar_type;
   MPI_Datatype MPI_SCALAR_TYPE = MpiTypeTraits<scalar_type>::getType ();
 
@@ -55,7 +58,10 @@ void ExchangeHalo_ref(const SparseMatrix_type & A, Vector_type & x) {
   int size, rank; // Number of MPI processes, My process ID
   MPI_Comm_size(A.comm, &size);
   MPI_Comm_rank(A.comm, &rank);
-  if (size == 1) return;
+  if (size == 1) {
+    HPGMP_RANGE_POP(__FUNCTION__);
+    return;
+  }
 
   //
   //  first post receives, these are immediate receives
@@ -122,6 +128,8 @@ void ExchangeHalo_ref(const SparseMatrix_type & A, Vector_type & x) {
 
   x.time1 = time1; x.time2 = time2;
   delete [] request;
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   return;
 }

--- a/src/GMRES.cpp
+++ b/src/GMRES.cpp
@@ -66,6 +66,7 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
           typename SparseMatrix_type::scalar_type & normr0,
           const bool doPreconditioning, const bool verbose, TestGMRESData_type& test_data)
 {
+  HPGMP_RANGE_PUSH(__FUNCTION__);
   typedef typename SparseMatrix_type::scalar_type scalar_type;
   typedef MultiVector<scalar_type> MultiVector_type;
   typedef SerialDenseMatrix<scalar_type> SerialDenseMatrix_type;
@@ -384,6 +385,8 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
   //test_data.flops[1] += flops_gmg;
   test_data.flops[2] += flops_spmv;
   test_data.flops[3] += flops_orth;
+
+  HPGMP_RANGE_POP(__FUNCTION__);
 
   if(IS_NAN(normr)) {
       return 2;

--- a/src/GMRES_IR.cpp
+++ b/src/GMRES_IR.cpp
@@ -67,6 +67,8 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
              int & niters, typename SparseMatrix_type::scalar_type & normr_hi, typename SparseMatrix_type::scalar_type & normr0_hi,
              const bool doPreconditioning, bool verbose, TestGMRESData_type & test_data) {
 
+  HPGMP_RANGE_PUSH(__FUNCTION__);
+
   // (working) precision for outer loop
   typedef typename SparseMatrix_type::scalar_type scalar_type;
   typedef MultiVector<scalar_type> MultiVector_type;
@@ -546,6 +548,7 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
   test_data.flops[2] += flops_spmv;
   test_data.flops[3] += flops_orth;
 
+  HPGMP_RANGE_POP(__FUNCTION__);
   if(!converged) {
       HPGMP_fout << "GMRES-IR did not converge!\n";
       return 1;

--- a/src/Profiling.hpp
+++ b/src/Profiling.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#ifdef HPGMP_WITH_PROFILING
+
+#if defined HPGMP_WITH_HIP || defined HPGMP_WITH_CUDA
+
+#ifdef HPGMP_WITH_HIP
+#include <roctracer/roctx.h>
+#define HPGMP_RANGE_PUSH(x) roctxRangePush(x)
+#define HPGMP_RANGE_POP(x)  roctxRangePop(); \
+	                    roctxMarkA(x)
+#endif // HPGMP_WITH_HIP
+
+#ifdef HPGMP_WITH_CUDA
+#include <nvToolsExt.h>
+#define HPGMP_RANGE_PUSH(x) nvtxRangePush(x)
+#define HPGMP_RANGE_POP(x)  nvtxRangePop(); \
+	                    nvtxMarkA(x)
+#endif // HPGMP_WITH_CUDA
+
+#else
+
+// Not using GPU
+#define HPGMP_RANGE_PUSH(x)
+#define HPGMP_RANGE_POP(x)
+
+#endif // HPGMP_WITH_HIP || HPGMP_WITH_CUDA
+
+#else
+
+// Not using profiling
+#define HPGMP_RANGE_PUSH(x)
+#define HPGMP_RANGE_POP(x)
+
+#endif // HPGMP_WITH_PROFILING

--- a/src/Profiling.hpp
+++ b/src/Profiling.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HPGMP_PROFILING_HPP
+#define HPGMP_PROFILING_HPP
 
 #ifdef HPGMP_WITH_PROFILING
 
@@ -33,3 +34,5 @@
 #define HPGMP_RANGE_POP(x)
 
 #endif // HPGMP_WITH_PROFILING
+
+#endif // HPGMP_PROFILING_HPP

--- a/src/Vector.dev.cpp
+++ b/src/Vector.dev.cpp
@@ -278,6 +278,9 @@ __global__ void haloGather(const int totalToBeSent, const scalar *const d_x,
 template <typename scalar>
 void Vector<scalar>::update_halos_pack_send_buffer(const DistMatrixBase *const mat) const
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
 #ifndef HPGMP_NO_MPI
     const MPI_Datatype MPI_SCALAR_TYPE = MpiTypeTraits<scalar>::getType ();
     const local_int_t localNumberOfRows = mat->get_local_num_rows();
@@ -299,8 +302,10 @@ void Vector<scalar>::update_halos_pack_send_buffer(const DistMatrixBase *const m
     auto comm = mat->get_comm();
     MPI_Comm_size(comm, &size);
     MPI_Comm_rank(comm, &rank);
-    if (size == 1)
+    if (size == 1) {
+        HPGMP_RANGE_POP(__FUNCTION__);
         return;
+    }
 
     const int MPI_MY_TAG = 99;
 
@@ -319,6 +324,7 @@ void Vector<scalar>::update_halos_pack_send_buffer(const DistMatrixBase *const m
 
     // Post receives first
     // Thread this loop
+    HPGMP_RANGE_PUSH("Post MPI_Irecv");
     double t0 = 0.0;
     TICK();
     for (int i = 0; i < num_neighbors; i++) {
@@ -328,9 +334,11 @@ void Vector<scalar>::update_halos_pack_send_buffer(const DistMatrixBase *const m
     }
     double time2 = 0.0;
     TOCK(time2);
+    HPGMP_RANGE_POP("Post MPI_Irecv");
 
 
     // Fill up send buffer
+    HPGMP_RANGE_PUSH("Fill send buffer");
     TICK();
     auto d_sendBuffer = static_cast<scalar_type*>(mat->get_device_send_buffer());
     const auto perm = mat->get_reordering_permutation();
@@ -361,8 +369,10 @@ void Vector<scalar>::update_halos_pack_send_buffer(const DistMatrixBase *const m
 
     double time1 = 0.0;
     TOCK(time1);
+    HPGMP_RANGE_POP("Fill send buffer");
 
     // Send to each neighbor
+    HPGMP_RANGE_PUSH("MPI_Send");
     TICK();
     for (int i = 0; i < num_neighbors; i++) {
         local_int_t n_send = sendLength[i];
@@ -376,6 +386,7 @@ void Vector<scalar>::update_halos_pack_send_buffer(const DistMatrixBase *const m
         MPI_Abort(comm, -2025);
     }
     TOCK(time2);
+    HPGMP_RANGE_POP("MPI_Send");
 
 #if !defined(HPGMP_USE_GPU_AWARE_MPI)
     // copy received data to GPU
@@ -387,6 +398,8 @@ void Vector<scalar>::update_halos_pack_send_buffer(const DistMatrixBase *const m
 #endif
     recv_reqs_.clear();
 #endif // HPGMP_NO_MPI
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 }
 
 template <typename scalar>
@@ -400,6 +413,9 @@ void Vector<scalar>::update_halos_finalize(const DistMatrixBase *const mat) cons
 template <typename scalar>
 void Vector<scalar>::update_halos_pack_send_buffer(const DistMatrixBase *const mat) const
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
 #ifndef HPGMP_NO_MPI
     const local_int_t totalToBeSent = mat->get_total_to_be_sent();
     scalar_type * const d_xv = d_values_;
@@ -436,11 +452,16 @@ void Vector<scalar>::update_halos_pack_send_buffer(const DistMatrixBase *const m
     //   waits to execute till the send buffer is gathered
     dctx_->stream_wait_on_event(interior_stream, send_gather_);
 #endif // HPGMP_NO_MPI
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 }
 
 template <typename scalar>
 void Vector<scalar>::update_halos_send_receive(const DistMatrixBase *const mat) const
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
 #ifndef HPGMP_NO_MPI
     const MPI_Datatype MPI_SCALAR_TYPE = MpiTypeTraits<scalar>::getType ();
     const local_int_t localNumberOfRows = mat->get_local_num_rows();
@@ -463,8 +484,10 @@ void Vector<scalar>::update_halos_send_receive(const DistMatrixBase *const mat) 
     int size, rank; // Number of MPI processes, My process ID
     MPI_Comm_size(comm, &size);
     MPI_Comm_rank(comm, &rank);
-    if (size == 1)
+    if (size == 1) {
+        HPGMP_RANGE_POP(__FUNCTION__);
         return;
+    }
     
     const int MPI_MY_TAG = 99;
 
@@ -500,9 +523,12 @@ void Vector<scalar>::update_halos_send_receive(const DistMatrixBase *const mat) 
         MPI_Isend(send_buffer, n_send, MPI_SCALAR_TYPE, neighbors[i], MPI_MY_TAG, comm, &send_reqs_[i]);
         send_buffer += n_send;
     }
-#endif
+#endif // HPGMP_NO_MPI
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 }
 
+#ifndef HPGMP_NO_MPI
 namespace internal {
 
 void check_waitall_error(const int ierr, const std::string& type)
@@ -538,10 +564,14 @@ void check_waitall_statuses(const std::string&& type, const int ierr,
 }
 
 }
+#endif // HPGMP_NO_MPI
 
 template <typename scalar>
 void Vector<scalar>::update_halos_finalize(const DistMatrixBase *const mat) const
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
 #ifndef HPGMP_NO_MPI
     // Complete the sends and receives.
     const local_int_t localNumberOfRows = mat->get_local_num_rows();
@@ -577,10 +607,13 @@ void Vector<scalar>::update_halos_finalize(const DistMatrixBase *const mat) cons
     halos_buffer_packed_ = false;
     recv_reqs_.clear();
     send_reqs_.clear();
-#endif
+#endif // HPGMP_NO_MPI
+
+    HPGMP_RANGE_POP(__FUNCTION__);
+
 }
 
-#endif
+#endif // HPGMP_ONLY_BLOCKING_COMMS
 
 
 template <unsigned int BLOCKSIZE, typename scalar>

--- a/src/ell_matrix.cpp
+++ b/src/ell_matrix.cpp
@@ -49,6 +49,8 @@
 
 #include "kernel_helpers.hpp.inc"
     
+#include "Profiling.hpp"
+    
 template <typename hiscalar, typename loscalar>
 ELLMatrix<hiscalar,loscalar>::ELLMatrix(const SparseMatrix<hiscalar>& A)
     : DistMatrixBase(A), ldv_{((local_nrows_ - 1) / pad_mult_v + 1) * pad_mult_v},
@@ -526,9 +528,15 @@ void ell_spmv(const ELLMatrix<hiscalar>* mat, const Vector<vscalar> *x, Vector<v
 template<class SparseMatrix_type, class Vector_type>
 int ComputeSPMV_ell(const SparseMatrix_type & A, Vector_type & x, Vector_type & y)
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     using scalar_type = typename SparseMatrix_type::scalar_type;
     auto elldata = static_cast<const EllOptData<scalar_type,scalar_type>*>(A.optimizationData);
     ell_spmv(elldata->mat.get(), &x, &y);
+
+    HPGMP_RANGE_POP(__FUNCTION__);
+
     return 0;
 }
 

--- a/src/hpgmp.hpp
+++ b/src/hpgmp.hpp
@@ -109,6 +109,8 @@ struct HPGMP_gen_opts {
 typedef HPGMP_Params_STRUCT HPGMP_Params;
 #ifdef HPGMP_NO_MPI
   typedef int comm_type;
+#define MPI_Abort(comm, errorcode) abort();
+#define MPI_Barrier(comm);
 #else
   #include "mpi.h"
   typedef MPI_Comm comm_type;

--- a/src/main_hpgmp.cpp
+++ b/src/main_hpgmp.cpp
@@ -92,8 +92,8 @@ int main(int argc, char * argv[]) {
   TICK();
 
   int myRank = 0;
-#ifndef HPGMP_NO_MPI
   int numRanks = 1;
+#ifndef HPGMP_NO_MPI
   MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
   MPI_Comm_size(MPI_COMM_WORLD, &numRanks);
 #endif
@@ -138,7 +138,8 @@ int main(int argc, char * argv[]) {
 #else
   comm_type validation_comm = 0;
   comm_type benchmark_comm = 0;
-#endif
+  const int sizeValidComm = 1;
+#endif // HPGMP_NO_MPI
 
   // Check if QuickPath option is enabled.
   // If the running time is set to zero, we minimize all paths through the program

--- a/src/mytimer.hpp
+++ b/src/mytimer.hpp
@@ -18,6 +18,7 @@
 #define MYTIMER_HPP
 
 #include "device_ctx.hpp"
+#include "Profiling.hpp"
 
 double mytimer(void);
 


### PR DESCRIPTION
This adds ROCTX and NVTX profiling annotations to functions of interest. This is useful to better correlate kernels to the functions where they are called, when collecting application traces.

To collect a trace with ROCm:
`rocprof --stats --roctx-trace --sys-trace -o xhpgmp.csv $EXEC $ARGS`

Note that this is using the `rocprofv1` approach with ROCm. Some of the includes will need to be updated for `rocprofv3` once we've verified that the latter works as expected. See https://github.com/ROCm/rocprofiler-sdk?tab=readme-ov-file#rocprofiler-sdk--application-profiling-tracing-and-performance-analysis.