### PR TITLE
Add run modes to include standalone runs for performance analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ set(host_sources
     src/SetupMatrix.cpp src/SetupProblem.cpp
     src/ValidGMRES.cpp src/BenchGMRES.cpp
     src/WriteProblem.cpp
-    src/YAML_Doc.cpp src/YAML_Element.cpp
+    src/YAML_Doc.cpp src/YAML_Element.cpp src/options_strings.cpp
     src/ComputeSPMV.cpp 
     src/ComputeDotProduct.cpp src/ComputeDotProduct_ref.cpp src/ComputeDotProduct_gpu.cpp src/ComputeDotProduct_blas.cpp
     src/ComputeTRSM.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ endif()
 
 set(host_sources
     src/device_ctx.cpp src/MultiVector.cpp src/SparseMatrix.cpp
-    src/GMRES.cpp src/GMRES_IR.cpp src/TestGMRES.cpp
+    src/GMRES.cpp src/GMRES_IR.cpp src/TestGMRES.cpp src/estimate_run_time.cpp
     src/ComputeResidual.cpp src/GenerateGeometry.cpp
     src/GenerateNonsymProblem.cpp src/GenerateNonsymProblem_v1_ref.cpp src/CheckProblem.cpp
     src/OptimizeProblem.cpp src/ReadHpgmpDat.cpp src/ReportResults.cpp

--- a/README.md
+++ b/README.md
@@ -11,7 +11,20 @@ at Oak Ridge National Laboratory.
 ## Introduction
 
 HPG-MxP is a software package that performs a fixed number of multigrid preconditioned
-(using a Gauss-Seidel smoother) Generalized minimal residual (PGMRES) iterations.
+(using a Gauss-Seidel smoother) Generalized minimal residual (PGMRES) iterations in order to
+solve a possibly nonsymmetric large sparse linear system of equations.
+It is designed to be a benchmark to measure a computer's performance for sparse linear algebra
+workloads typical in scientific computing while allowing the use of mixed precision methods.
+The solution is required to have convergence characteristics and accuracy similar to
+double precision GMRES.
+It is based on the High Performance Conjugate Gradient Benchmark ([HPCG](https://github.com/hpcg-benchmark/hpcg))
+which restricts all implementations to use only the IEEE double precision format (FP64).
+This is somewhat analogous to how the High Performance Linpack
+([HPL](https://icl.utk.edu/hpl/index.html)) benchmark solves a large dense linear system
+and restricts the numerical format to FP64, while the [HPL-MxP](https://github.com/ROCm/rocHPL-MxP)
+benchmark solves an easier system but uses iterative refinement to allow the use of
+lower precision formats in the factorization stage while still obtaining a solution as accurate
+as using only FP64.
 
 The HPG-MxP rating is is a weighted GFLOP/s (billion floating operations per second) value
 that is composed of the operations performed in the PGMRES iteration phase over
@@ -31,10 +44,12 @@ These various modes are required in order to address sufficiently big problems
 if the range of indexing goes above 2^31 (roughly 2.1B), or to conserve storage
 costs if the range of indexing is less than 2^31.
 
-The  HPG-MxP  software  package requires the availibility on your system of an
-implementation of the  Message Passing Interface (MPI) if enabling the MPI
-build of HPG-MxP, and a compiler that supports OpenMP syntax. An implementation
-compliant with MPI version 1.1 is sufficient.
+This HPG-MxP software package requires the availibility on your system of an
+implementation of the Message Passing Interface (MPI) if enabling the MPI
+build of HPG-MxP, a compiler that supports OpenMP syntax, and an accelerator compiler
+and library ecosystem.
+
+This implementation uses several ideas from AMD's HPCG implementation [rocHPCG](https://github.com/ROCm/rocHPCG).
 
 ## Installation
 
@@ -67,3 +82,10 @@ size should reflect what would be reasonable for a real sparse iterative solver.
 
 Known problems and bugs with this release are documented in the file
 `BUGS`.
+
+## Citing
+
+The additional optimizations, features and other changes over the reference implementation are
+described in the paper:
+Kashi et al., "Scaling the memory wall using mixed-precision - HPG-MxP on an exascale machine",
+arXiv:2507.11512 [cs.DC], July 2025.

--- a/doc/run.md
+++ b/doc/run.md
@@ -20,6 +20,24 @@ then you can run the following::
     mpirun -np 8 xhpgmp 32 24 16
 ```
 
+## Other command line options
+
+### Running modes
+
+There are 4 possible run modes for the code, selected at run time by the `xhpgmp` flag `--run_type` with 4 possible values:
+- `benchmark`: The regular benchmark run with the timed double precision GMRES run in the end. Includes validation. Default.
+- `benchmark_no_ref`: Regular benchmark but without double precision GMRES run in the end. Includes validation.
+- `standalone_mxp`: Excludes validation, and only performs 10 timed MxP GMRES-IR runs. Ignores running time.
+- `standalone_ref`: Excludes validation, and only performs 10 repetitions of double precision GMRES.
+
+### Validation modes
+
+The standard benchmark by Yamazaki et al. defines the validation phase on a small fixed number of ranks, typically 1 node. It then converges the double-precision GMRES on that sub-communicator of processes to 9 orders of magnitude, followed by mixed-precision GMRES-IR to 9 orders of magnitude. The ratio of iterations requried, $ n_d / n_{mxp} $ is taken as the ratio to penalize the final attained GFLOPS number.
+
+However, there may be a concern that this may underestimate the degradation of convergence in real applications. We introduced validation at full scale to address this issue. All the processes available in the run, and used for the benchmarking phase, are also used for the validation phase. The global problem size used for the two phases is also the same. Two modes are provided:
+- `standard`: Standard 1-node validation of Yamazaki et al.
+- `fullscale`: Full scale DP GMRES is performed to a maximum of $n_d$ (10,000) iterations or relative residual tolerance 1e-9 (whichever comes first), and the attained residual reduction is recorded. This value is set as the tolerance for MxP GMRES-IR and the number of iterations $n_{mxp}$ are recorded.
+
 ## Setting up the input data file hpgmp.dat
 
 Current as of release HPGMP - 0.1 - May 5, 2023

--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -65,7 +65,7 @@ void test_mg_spmv(MPI_Comm comm, DeviceCtx *dctx, const Geometry *const geom,
  */
 template<class TestGMRESDataType, class scalar_type, class scalar_type2, class project_type>
 int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int numberOfMgLevels,
-               bool verbose, bool runReference, const bool validation_failure,
+               const bool verbose, const bool validation_failure, const HPGMP_gen_opts& gopts,
                TestGMRESDataType & test_data)
 {
   HPGMP_RANGE_PUSH(__FUNCTION__);
@@ -131,6 +131,8 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
   // =====================================================================
   // Run optimized GMRES (here, we are calling GMRES_IR) for a fixed number of iterations
   // and record the obtained Gflop/s
+  if(gopts.run_type == run_t::benchmark || gopts.run_type == run_t::benchmark_no_ref
+          || gopts.run_type == run_t::standalone_mxp)
   {
     //warmup
     x.fill_zero();
@@ -267,6 +269,10 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
         test_data.opt_times_comp[i] = test_data.times_comp[i];
     for (int i=0; i<n_timed_ops; i++)
         test_data.opt_times_comm[i] = test_data.times_comm[i];
+  } else {
+    // If mxp was not run
+    test_data.optTotalFlops = 0.0;
+    test_data.optTotalTime  = 0.0;
   }
 
   const double benchmark_done = mytimer();
@@ -279,7 +285,7 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
   // (Optional)
   // Run reference GMRES implementation for a fixed number of iterations
   // and record the obtained Gflop/s
-  if (runReference) {
+  if (gopts.run_type == run_t::benchmark || gopts.run_type == run_t::standalone_ref) {
 #ifdef HPGMP_WITH_PROFILING
     const int n_ref_calls = 1;
 #else
@@ -371,7 +377,7 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
   }
     
   // Report results 
-  ReportResults(A, numberOfMgLevels, test_data, validation_failure);
+  ReportResults(A, numberOfMgLevels, test_data, validation_failure, gopts);
 
   const double reporting_done = mytimer();
   if(A.geom->rank == 0) {
@@ -402,17 +408,20 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
 // uniform version
 template
 int BenchGMRES< TestGMRESData<double>, double, double, double >
-  (int, char**, comm_type, DeviceCtx*, int, bool, bool, bool, TestGMRESData<double>&);
+  (int, char**, comm_type, DeviceCtx*, int, bool, bool, const HPGMP_gen_opts&,
+   TestGMRESData<double>&);
 
 template
 int BenchGMRES< TestGMRESData<float>, float, float, float >
-  (int, char**, comm_type, DeviceCtx*, int, bool, bool, bool, TestGMRESData<float>&);
+  (int, char**, comm_type, DeviceCtx*, int, bool, bool, const HPGMP_gen_opts&,
+   TestGMRESData<float>&);
 
 
 // mixed version
 template
 int BenchGMRES< TestGMRESData<double>, double, float, float >
-  (int, char**, comm_type, DeviceCtx*, int, bool, bool, bool, TestGMRESData<double>&);
+  (int, char**, comm_type, DeviceCtx*, int, bool, bool, const HPGMP_gen_opts&,
+   TestGMRESData<double>&);
 
 
 template<class TestGMRESDataType, class SparseMatrixType, class VectorType>

--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -52,12 +52,19 @@ void test_mg_spmv(MPI_Comm comm, DeviceCtx *dctx, const Geometry *const geom,
                   const SparseMatrixType& A, TestGMRESData& test_data);
 
 // Get number of iterations to fill the required time
-inline int get_num_iterations(const double runTime, const double minOfficialTime,
-                              const double avg_gmres_time, const run_t run_type)
+template<typename scalar_type, typename scalar_type2>
+inline int get_num_iterations(comm_type comm,
+        const SparseMatrix<scalar_type>& A, const SparseMatrix<scalar_type2>& A_lo,
+        GMRESData<scalar_type>& data, GMRESData<scalar_type2>& data_lo,
+        const Vector<scalar_type>& b, Vector<scalar_type>& x, int max_iters,
+        const int restart_length, const bool verbose,
+        const double runTime, const double minOfficialTime, const run_t run_type)
 {
-    const int numberOfGmresCalls = runTime >= 0.0 ?
-        ceil(runTime / avg_gmres_time) : ceil(minOfficialTime / avg_gmres_time);
     if(run_type == run_t::benchmark || run_type == run_t::benchmark_no_ref) {
+        const double avg_run_time = estimate_run_time(comm, A, A_lo, data, data_lo, b, x,
+                max_iters, restart_length, verbose);
+        const int numberOfGmresCalls = runTime >= 0.0 ?
+            ceil(runTime / avg_run_time) : ceil(minOfficialTime / avg_run_time);
         return numberOfGmresCalls;
     } else {
         return non_benchmark_num_runs;
@@ -152,12 +159,10 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
 #ifdef HPGMP_WITH_PROFILING
     const int numberOfGmresCalls = 1;
 #else // HPGMP_WITH_PROFILING
-    const double avg_run_time = estimate_run_time(comm, A, A_lo, data, data_lo, b, x, maxIters,
-            restart_length, verbose);
-
-    // Get number of iterations to fill the required time
-    const int numberOfGmresCalls = get_num_iterations(test_data.runningTime,
-            test_data.minOfficialTime, avg_run_time, gopts.run_type);
+    // Get number of iterations to fill the required time depending on the run type
+    const int numberOfGmresCalls = get_num_iterations(
+            comm, A, A_lo, data, data_lo, b, x, maxIters, restart_length, verbose,
+            test_data.runningTime, test_data.minOfficialTime, gopts.run_type);
 #endif // HPGMP_WITH_PROFILING
 
     if (A.geom->rank==0) {

--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -43,11 +43,12 @@ using std::endl;
 #include "BenchGMRES.hpp"
 #include "mytimer.hpp"
 #include "ReportResults.hpp"
+#include "estimate_run_time.hpp"
 
 /// Record execution time of SpMV and MG kernels for reporting times
-template<class TestGMRESDataType, class SparseMatrixType, class VectorType>
+template<class SparseMatrixType, class VectorType>
 void test_mg_spmv(MPI_Comm comm, DeviceCtx *dctx, const Geometry *const geom,
-                      const SparseMatrixType& A, TestGMRESDataType& test_data);
+                  const SparseMatrixType& A, TestGMRESData& test_data);
 
 /*!
   Benchmark the optimized GMRES implementation
@@ -63,10 +64,10 @@ void test_mg_spmv(MPI_Comm comm, DeviceCtx *dctx, const Geometry *const geom,
 
   @see GMRES()
  */
-template<class TestGMRESDataType, class scalar_type, class scalar_type2, class project_type>
+template<class scalar_type, class scalar_type2, class project_type>
 int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int numberOfMgLevels,
                const bool verbose, const bool validation_failure, const HPGMP_gen_opts& gopts,
-               TestGMRESDataType & test_data)
+               TestGMRESData& test_data)
 {
   HPGMP_RANGE_PUSH(__FUNCTION__);
   typedef Vector<scalar_type> Vector_type;
@@ -98,7 +99,7 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
   }
 
   // Record execution time of reference SpMV and MG kernels for reporting times
-  test_mg_spmv<TestGMRESDataType, SparseMatrix_type, Vector_type>(comm, dctx, geom, A, test_data);
+  test_mg_spmv<SparseMatrix_type, Vector_type>(comm, dctx, geom, A, test_data);
 
   const double setup_done = mytimer();
   if(geom->rank == 0) {
@@ -125,8 +126,8 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
   const bool precond = true;
   test_data.maxNumIters = maxIters;
     
-  constexpr int n_fl_ops = TestGMRESDataType::n_fl_ops;
-  constexpr int n_timed_ops = TestGMRESDataType::n_timed_ops;
+  constexpr int n_fl_ops = TestGMRESData::n_fl_ops;
+  constexpr int n_timed_ops = TestGMRESData::n_timed_ops;
 
   // =====================================================================
   // Run optimized GMRES (here, we are calling GMRES_IR) for a fixed number of iterations
@@ -134,59 +135,18 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
   if(gopts.run_type == run_t::benchmark || gopts.run_type == run_t::benchmark_no_ref
           || gopts.run_type == run_t::standalone_mxp)
   {
-    //warmup
-    x.fill_zero();
-    GMRES_IR(A, A_lo, data, data_lo, b, x, restart_length, maxIters, tolerance, niters,
-             normr, normr0, precond, verbose, test_data);
-#ifdef HPGMP_VERBOSE
-    MPI_Barrier(comm);
-    if(geom->rank == 0) {
-        std::cout << "BenchGMRES: Completed warmup GMRES-IR run." << std::endl;
-    }
-#endif
-    if (verbose && A.geom->rank==0) {
-      HPGMP_fout << "Warm-up runs" << endl;
-    }
-
 #ifdef HPGMP_WITH_PROFILING
     const int numberOfGmresCalls = 1;
 #else // HPGMP_WITH_PROFILING
-    const int timing_calls = 10;
-    double gmresir_run_time = 0;
-    
-    for (int i=0; i < timing_calls; ++i) {
-      x.fill_zero();
-
-      const double time_tic = mytimer();
-      const int ierr = GMRES_IR(A, A_lo, data, data_lo, b, x,
-                                restart_length, maxIters, tolerance, niters, normr, normr0,
-                                precond, verbose, test_data);
-      gmresir_run_time += (mytimer() - time_tic);
-      if(i == 0) {
-        if (A.geom->rank==0) {
-            std::cout << "BenchGMRES: Time taken by first timing solve = " << gmresir_run_time
-                      << std::endl;
-            std::cout << "BenchGMRES: Iterations taken by first timing solve = " << niters
-                      << std::endl;
-        }
-      }
-    }
-
-    gmresir_run_time /= timing_calls;
-
-    double avg_run_time = 0;
-#ifndef HPGMP_NO_MPI
-    MPI_Allreduce(&gmresir_run_time, &avg_run_time, 1, MPI_DOUBLE, MPI_SUM, comm);
-#else
-    avg_run_time = gmresir_run_time;
-#endif
-    avg_run_time /= geom->size;
+    const double avg_run_time = estimate_run_time(comm, A, A_lo, data, data_lo, b, x, maxIters,
+            restart_length, verbose);
 
     // Get number of iterations to fill the required time
     const int numberOfGmresCalls = test_data.runningTime >= 0.0 ?
         ceil(test_data.runningTime / avg_run_time) :
         ceil(test_data.minOfficialTime / avg_run_time);
 #endif // HPGMP_WITH_PROFILING
+
     if (A.geom->rank==0) {
         std::cout << "Number of benchmarking GMRES runs will be " << numberOfGmresCalls
                   << std::endl;
@@ -216,9 +176,6 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
                                 precond, verbose, test_data);
       const double time_toc = (mytimer() - time_tic);
       time_solve_total += time_toc;
-
-      if (i == 0) {
-      }
 
       if (ierr > 1) {
           HPGMP_fout << "NaN Error in call to GMRES-IR: " << ierr << ".\n" << endl;
@@ -407,26 +364,26 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
 
 // uniform version
 template
-int BenchGMRES< TestGMRESData<double>, double, double, double >
+int BenchGMRES<double, double, double >
   (int, char**, comm_type, DeviceCtx*, int, bool, bool, const HPGMP_gen_opts&,
-   TestGMRESData<double>&);
+   TestGMRESData&);
 
 template
-int BenchGMRES< TestGMRESData<float>, float, float, float >
+int BenchGMRES<float, float, float >
   (int, char**, comm_type, DeviceCtx*, int, bool, bool, const HPGMP_gen_opts&,
-   TestGMRESData<float>&);
+   TestGMRESData&);
 
 
 // mixed version
 template
-int BenchGMRES< TestGMRESData<double>, double, float, float >
+int BenchGMRES<double, float, float >
   (int, char**, comm_type, DeviceCtx*, int, bool, bool, const HPGMP_gen_opts&,
-   TestGMRESData<double>&);
+   TestGMRESData&);
 
 
-template<class TestGMRESDataType, class SparseMatrixType, class VectorType>
+template<class SparseMatrixType, class VectorType>
 void test_mg_spmv(MPI_Comm comm, DeviceCtx *const dctx, const Geometry *const geom,
-                  const SparseMatrixType& A, TestGMRESDataType& test_data)
+                  const SparseMatrixType& A, TestGMRESData& test_data)
 {
     const local_int_t nrow = A.localNumberOfRows;
     const local_int_t ncol = A.localNumberOfColumns;

--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -29,7 +29,6 @@
 #include <vector>
 #include <math.h>
 #include <stdexcept>
-using std::endl;
 
 #include "hpgmp.hpp"
 
@@ -45,10 +44,25 @@ using std::endl;
 #include "ReportResults.hpp"
 #include "estimate_run_time.hpp"
 
+constexpr int non_benchmark_num_runs = 10;
+
 /// Record execution time of SpMV and MG kernels for reporting times
 template<class SparseMatrixType, class VectorType>
 void test_mg_spmv(MPI_Comm comm, DeviceCtx *dctx, const Geometry *const geom,
                   const SparseMatrixType& A, TestGMRESData& test_data);
+
+// Get number of iterations to fill the required time
+inline int get_num_iterations(const double runTime, const double minOfficialTime,
+                              const double avg_gmres_time, const run_t run_type)
+{
+    const int numberOfGmresCalls = runTime >= 0.0 ?
+        ceil(runTime / avg_gmres_time) : ceil(minOfficialTime / avg_gmres_time);
+    if(run_type == run_t::benchmark || run_type == run_t::benchmark_no_ref) {
+        return numberOfGmresCalls;
+    } else {
+        return non_benchmark_num_runs;
+    }
+}
 
 /*!
   Benchmark the optimized GMRES implementation
@@ -142,13 +156,12 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
             restart_length, verbose);
 
     // Get number of iterations to fill the required time
-    const int numberOfGmresCalls = test_data.runningTime >= 0.0 ?
-        ceil(test_data.runningTime / avg_run_time) :
-        ceil(test_data.minOfficialTime / avg_run_time);
+    const int numberOfGmresCalls = get_num_iterations(test_data.runningTime,
+            test_data.minOfficialTime, avg_run_time, gopts.run_type);
 #endif // HPGMP_WITH_PROFILING
 
     if (A.geom->rank==0) {
-        std::cout << "Number of benchmarking GMRES runs will be " << numberOfGmresCalls
+        std::cout << "Number of MxP GMRES-IR runs will be " << numberOfGmresCalls
                   << std::endl;
     }
 
@@ -178,9 +191,9 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
       time_solve_total += time_toc;
 
       if (ierr > 1) {
-          HPGMP_fout << "NaN Error in call to GMRES-IR: " << ierr << ".\n" << endl;
+          HPGMP_fout << "NaN Error in call to GMRES-IR: " << ierr << ".\n" << std::endl;
           if (A.geom->rank==0)
-              std::cout << "NaN Error in call to GMRES-IR!\n" << endl;
+              std::cout << "NaN Error in call to GMRES-IR!\n" << std::endl;
           MPI_Abort(comm, -25);
       }
 
@@ -192,9 +205,9 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
         if(verbose) {
             HPGMP_fout << "Call [" << i << " / " << numberOfGmresCalls
                        << "] Number of GMRES-IR Iterations ["
-                       << niters <<"] Scaled Residual [" << normr/normr0 << "]" << endl;
-            HPGMP_fout << " Time        " << time_toc << endl;
-            HPGMP_fout << " Time/itr    " << time_toc / niters << endl;
+                       << niters <<"] Scaled Residual [" << normr/normr0 << "]" << std::endl;
+            HPGMP_fout << " Time        " << time_toc << std::endl;
+            HPGMP_fout << " Time/itr    " << time_toc / niters << std::endl;
         }
       }
     }
@@ -203,10 +216,10 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
     }
     if (verbose && A.geom->rank==0) {
       double flops = test_data.flops[0];
-      HPGMP_fout << "  Accumulated Time " << time_solve_total << " seconds." << endl;
+      HPGMP_fout << "  Accumulated Time " << time_solve_total << " seconds." << std::endl;
       HPGMP_fout << "  Final Gflop/s    " << flops/1000000000.0 << "/" << time_solve_total << " = "
                  << (flops/1000000000.0)/time_solve_total
-                 << " (n = " << A.totalNumberOfRows << ")" << endl;
+                 << " (n = " << A.totalNumberOfRows << ")" << std::endl;
     }
     test_data.optTotalTime = time_solve_total;
     test_data.numOfCalls = numberOfGmresCalls;
@@ -246,7 +259,7 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
 #ifdef HPGMP_WITH_PROFILING
     const int n_ref_calls = 1;
 #else
-    const int n_ref_calls = 10;
+    const int n_ref_calls = non_benchmark_num_runs;
 #endif
     x.fill_zero();
     //warmup
@@ -276,30 +289,30 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
       time_solve_total += time_toc;
 
       if (ierr == 2) {
-          HPGMP_fout << "NaN Error in call to GMRES: " << ierr << ".\n" << endl;
+          HPGMP_fout << "NaN Error in call to GMRES: " << ierr << ".\n" << std::endl;
           if (A.geom->rank==0)
               std::cout << "NaN Error in call to GMRES!" << std::endl;
       }
       if (A.geom->rank==0) {
         HPGMP_fout << "Call [" << i << " / " << n_ref_calls << "]";
         HPGMP_fout << " Number of GMRES Iterations [" << niters <<"] Scaled Residual ["
-                   << normr/normr0 << "]" << endl;
-        HPGMP_fout << " Time        " << time_toc << endl;
-        HPGMP_fout << " Time/itr    " << time_toc / niters << endl;
+                   << normr/normr0 << "]" << std::endl;
+        HPGMP_fout << " Time        " << time_toc << std::endl;
+        HPGMP_fout << " Time/itr    " << time_toc / niters << std::endl;
         std::cout << " BenchGMRES reference Call [" << i << " / " << n_ref_calls << "]";
         std::cout << " Number of GMRES Iterations [" << niters <<"] Scaled Residual ["
-                  << normr/normr0 << "]" << endl;
-        std::cout << "     Time        " << time_toc << endl;
-        std::cout << "     Time/itr    " << time_toc / niters << endl;
+                  << normr/normr0 << "]" << std::endl;
+        std::cout << "     Time        " << time_toc << std::endl;
+        std::cout << "     Time/itr    " << time_toc / niters << std::endl;
       }
     }
     if (verbose && A.geom->rank==0)
     {
       const double flops = test_data.flops[0];
-      HPGMP_fout << "  Accumulated Time " << time_solve_total << " seconds." << endl;
+      HPGMP_fout << "  Accumulated Time " << time_solve_total << " seconds." << std::endl;
       HPGMP_fout << "  Final Gflop/s    " << flops/1000000000.0 << "/" << time_solve_total
                  << " = " << (flops/1000000000.0)/time_solve_total 
-                 << " (n = " << A.totalNumberOfRows << ")" << endl;
+                 << " (n = " << A.totalNumberOfRows << ")" << std::endl;
     }
     test_data.refTotalTime  = test_data.times[0];
 
@@ -348,8 +361,8 @@ int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *const dctx, int
 
   if (verbose && A.geom->rank==0) {
     const auto total_benchmark_time = (mytimer() - benchmark_begin_time);
-    HPGMP_fout << " Total benchmark time : " << total_benchmark_time << " seconds." << endl;
-    std::cout << " Total benchmark time : " << total_benchmark_time << " seconds." << endl;
+    HPGMP_fout << " Total benchmark time : " << total_benchmark_time << " seconds." << std::endl;
+    std::cout << " Total benchmark time : " << total_benchmark_time << " seconds." << std::endl;
   }
 
   delete geom;
@@ -407,7 +420,7 @@ void test_mg_spmv(MPI_Comm comm, DeviceCtx *const dctx, const Geometry *const ge
           std::cout << "  test_mg_spmv: Completed SpMV." << std::endl;
       }
 #endif
-      if (ierr) HPGMP_fout << "Error in call to SpMV: " << ierr << ".\n" << endl;
+      if (ierr) HPGMP_fout << "Error in call to SpMV: " << ierr << ".\n" << std::endl;
 
       if(i == 0) {
           ierr = ComputeMG(A, b_computed, x_overlap, symmetric, ft0); // b_computed = Minv*y_overlap
@@ -416,7 +429,7 @@ void test_mg_spmv(MPI_Comm comm, DeviceCtx *const dctx, const Geometry *const ge
           ierr = ComputeMG(A, b_computed, x_overlap, symmetric, ft); // b_computed = Minv*y_overlap
           TOCK(mgtime);
       }
-      if (ierr) HPGMP_fout << "Error in call to MG: " << ierr << ".\n" << endl;
+      if (ierr) HPGMP_fout << "Error in call to MG: " << ierr << ".\n" << std::endl;
     }
 #ifdef HPGMP_VERBOSE
     if(geom->rank == 0) {

--- a/src/BenchGMRES.hpp
+++ b/src/BenchGMRES.hpp
@@ -31,7 +31,8 @@
 
 template<class TestGMRESData_type, class scalar_type, class scalar_type2, class project_type = scalar_type2>
 int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *dctx, int numberOfMgLevels,
-               bool verbose, bool runReference, bool validation_failure, TestGMRESData_type & testcg_data);
+               bool verbose, bool validation_failure, const HPGMP_gen_opts& gopts,
+               TestGMRESData_type & testcg_data);
 
 #endif  // BENCHGMRES_HPP
 

--- a/src/BenchGMRES.hpp
+++ b/src/BenchGMRES.hpp
@@ -29,10 +29,10 @@
 #include "device_ctx.hpp"
 #include "GMRESData.hpp"
 
-template<class TestGMRESData_type, class scalar_type, class scalar_type2, class project_type = scalar_type2>
+template<class scalar_type, class scalar_type2, class project_type = scalar_type2>
 int BenchGMRES(int argc, char **argv, comm_type comm, DeviceCtx *dctx, int numberOfMgLevels,
                bool verbose, bool validation_failure, const HPGMP_gen_opts& gopts,
-               TestGMRESData_type & testcg_data);
+               TestGMRESData& testcg_data);
 
 #endif  // BENCHGMRES_HPP
 

--- a/src/GMRES.cpp
+++ b/src/GMRES.cpp
@@ -58,13 +58,13 @@
 
   @see GMRES_ref()
 */
-template<class SparseMatrix_type, class GMRESData_type, class Vector_type, class TestGMRESData_type>
+template<class SparseMatrix_type, class GMRESData_type, class Vector_type>
 int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b, Vector_type& x,
           const int restart_length, const int max_iter,
           const typename SparseMatrix_type::scalar_type tolerance,
           int & niters, typename SparseMatrix_type::scalar_type & normr,
           typename SparseMatrix_type::scalar_type & normr0,
-          const bool doPreconditioning, const bool verbose, TestGMRESData_type& test_data)
+          const bool doPreconditioning, const bool verbose, TestGMRESData& test_data)
 {
   HPGMP_RANGE_PUSH(__FUNCTION__);
   typedef typename SparseMatrix_type::scalar_type scalar_type;
@@ -402,12 +402,12 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
  * --------------- */
 
 template
-int GMRES< SparseMatrix<double>, GMRESData<double>, Vector<double>, TestGMRESData<double> >
+int GMRES< SparseMatrix<double>, GMRESData<double>, Vector<double>>
   (SparseMatrix<double> const&, GMRESData<double>&, Vector<double> const&, Vector<double>&,
-   const int, const int, double, int&, double&, double&, bool, bool, TestGMRESData<double>&);
+   const int, const int, double, int&, double&, double&, bool, bool, TestGMRESData&);
 
 template
-int GMRES< SparseMatrix<float>, GMRESData<float>, Vector<float>, TestGMRESData<float> >
+int GMRES< SparseMatrix<float>, GMRESData<float>, Vector<float>>
   (SparseMatrix<float> const&, GMRESData<float>&, Vector<float> const&, Vector<float>&,
-   const int, const int, float, int&, float&, float&, bool, bool, TestGMRESData<float>&);
+   const int, const int, float, int&, float&, float&, bool, bool, TestGMRESData&);
 

--- a/src/GMRES.hpp
+++ b/src/GMRES.hpp
@@ -23,11 +23,11 @@
 #include "SerialDenseMatrix.hpp"
 #include "GMRESData.hpp"
 
-template<class SparseMatrix_type, class GMRESData_type, class Vector_type, class TestGMRESData_type>
+template<class SparseMatrix_type, class GMRESData_type, class Vector_type>
 int GMRES(const SparseMatrix_type & A, GMRESData_type & data, const Vector_type & b, Vector_type & x,
           const int restart_length, const int max_iter, const typename SparseMatrix_type::scalar_type tolerance,
           int & niters, typename SparseMatrix_type::scalar_type & normr, typename SparseMatrix_type::scalar_type & normr0,
-          bool doPreconditioning, bool verbose, TestGMRESData_type & test_data);
+          bool doPreconditioning, bool verbose, TestGMRESData& test_data);
 
 // this function will compute the Conjugate Gradient iterations.
 // geom - Domain and processor topology information

--- a/src/GMRESData.hpp
+++ b/src/GMRESData.hpp
@@ -66,14 +66,13 @@ public:
 };
 
 
-template<class SC>
 class TestGMRESData {
 public:
   static constexpr int n_fl_ops = 4;     ///< Number of numerical operations for which flops are counted in GMRES
   static constexpr int n_timed_ops = 12; ///< Number of operations which are timed in GMRES
 
   int restart_length;     //!< restart length
-  SC tolerance;           //!< tolerance = reference residual norm 
+  double tolerance;           //!< tolerance = reference residual norm 
   double runningTime;     //!<
   double minOfficialTime; //!<
 

--- a/src/GMRES_IR.cpp
+++ b/src/GMRES_IR.cpp
@@ -60,12 +60,12 @@
 
   @see GMRES_IR_ref()
 */
-template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type, class TestGMRESData_type>
+template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type>
 int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
              GMRESData_type & data, GMRESData_type2 & data_lo, const Vector_type & b_hi, Vector_type & x_hi,
              const int restart_length, const int max_iter, const typename SparseMatrix_type::scalar_type tolerance,
              int & niters, typename SparseMatrix_type::scalar_type & normr_hi, typename SparseMatrix_type::scalar_type & normr0_hi,
-             const bool doPreconditioning, bool verbose, TestGMRESData_type & test_data) {
+             const bool doPreconditioning, bool verbose, TestGMRESData& test_data) {
 
   HPGMP_RANGE_PUSH(__FUNCTION__);
 
@@ -567,21 +567,21 @@ int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
 
 // uniform
 template
-int GMRES_IR< SparseMatrix<double>, SparseMatrix<double>, GMRESData<double>, GMRESData<double>, Vector<double>, TestGMRESData<double> >
+int GMRES_IR< SparseMatrix<double>, SparseMatrix<double>, GMRESData<double>, GMRESData<double>, Vector<double>>
   (SparseMatrix<double> const&, SparseMatrix<double> const&, GMRESData<double>&, GMRESData<double>&,
    Vector<double> const&, Vector<double>&, const int, const int, double, int&, double&, double&, bool, bool,
-   TestGMRESData<double>&);
+   TestGMRESData&);
 
 template
-int GMRES_IR< SparseMatrix<float>, SparseMatrix<float>, GMRESData<float>, GMRESData<float>, Vector<float>, TestGMRESData<float> >
+int GMRES_IR< SparseMatrix<float>, SparseMatrix<float>, GMRESData<float>, GMRESData<float>, Vector<float>>
   (SparseMatrix<float> const&, SparseMatrix<float> const&, GMRESData<float>&, GMRESData<float>&,
    Vector<float> const&, Vector<float>&, const int, const int, float, int&, float&, float&, bool, bool,
-   TestGMRESData<float>&);
+   TestGMRESData&);
 
 
 // mixed
 template
-int GMRES_IR< SparseMatrix<double>, SparseMatrix<float>, GMRESData<double>, GMRESData<float>, Vector<double>, TestGMRESData<double> >
+int GMRES_IR< SparseMatrix<double>, SparseMatrix<float>, GMRESData<double>, GMRESData<float>, Vector<double>>
   (SparseMatrix<double> const&, SparseMatrix<float> const&, GMRESData<double>&, GMRESData<float>&,
    Vector<double> const&, Vector<double>&, const int, const int, double, int&, double&, double&, bool, bool,
-   TestGMRESData<double>&);
+   TestGMRESData&);

--- a/src/GMRES_IR.hpp
+++ b/src/GMRES_IR.hpp
@@ -23,12 +23,12 @@
 #include "SerialDenseMatrix.hpp"
 #include "GMRESData.hpp"
 
-template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type, class TestGMRESData_type>
+template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type>
 int GMRES_IR(const SparseMatrix_type & A, const SparseMatrix_type2 & A_lo,
              GMRESData_type & data, GMRESData_type2 & data_lo, const Vector_type & b_hi, Vector_type & x_hi,
              const int restart_length, const int max_iter, const typename SparseMatrix_type::scalar_type tolerance,
              int & niters, typename SparseMatrix_type::scalar_type & normr, typename SparseMatrix_type::scalar_type & normr0,
-             bool doPreconditioning, bool verbose, TestGMRESData_type& test_data);
+             bool doPreconditioning, bool verbose, TestGMRESData& test_data);
 
 // this function will compute the Conjugate Gradient iterations.
 // geom - Domain and processor topology information

--- a/src/ReportResults.cpp
+++ b/src/ReportResults.cpp
@@ -47,9 +47,9 @@
 
   @see YAML_Doc
 */
-template<class SparseMatrix_type, class TestGMRESData_type>
+template<class SparseMatrix_type>
 void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
-                   const TestGMRESData_type & test_data, const int global_failure,
+                   const TestGMRESData& test_data, const int global_failure,
                    const HPGMP_gen_opts& gopts) {
 
   typedef typename SparseMatrix_type::scalar_type scalar_type;
@@ -473,9 +473,9 @@ void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
  * specializations *
  * --------------- */
 template
-void ReportResults< SparseMatrix<double>, TestGMRESData<double> >
-  (const SparseMatrix<double>&, int, const TestGMRESData<double>&, int, const HPGMP_gen_opts&);
+void ReportResults< SparseMatrix<double>>
+  (const SparseMatrix<double>&, int, const TestGMRESData&, int, const HPGMP_gen_opts&);
 
 template
-void ReportResults< SparseMatrix<float>, TestGMRESData<float> >
-  (const SparseMatrix<float>&, int, const TestGMRESData<float>&, int, const HPGMP_gen_opts&);
+void ReportResults< SparseMatrix<float>>
+  (const SparseMatrix<float>&, int, const TestGMRESData&, int, const HPGMP_gen_opts&);

--- a/src/ReportResults.cpp
+++ b/src/ReportResults.cpp
@@ -31,10 +31,9 @@
 
 #ifdef HPGMP_DEBUG
 #include <fstream>
-using std::endl;
+#endif
 
 #include "hpgmp.hpp"
-#endif
 
 /*!
  Creates a YAML file and writes the information about the HPGMP run, its results, and validity.
@@ -50,7 +49,8 @@ using std::endl;
 */
 template<class SparseMatrix_type, class TestGMRESData_type>
 void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
-                   const TestGMRESData_type & test_data, int global_failure) {
+                   const TestGMRESData_type & test_data, const int global_failure,
+                   const HPGMP_gen_opts& gopts) {
 
   typedef typename SparseMatrix_type::scalar_type scalar_type;
   typedef Vector<scalar_type> Vector_type;
@@ -169,9 +169,19 @@ void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
     // Count number of bytes used per equation
     double fnbytesPerEquation = fnbytes/fnrow;
 
+    // Run type and validation type
+
     // Instantiate YAML document
     OutputFile doc("HPGMP-Benchmark", "0.1");
     doc.add("Release date", "May 5, 2023");
+    doc.add("Run type", get_string(gopts.run_type));
+    const bool is_benchmark = (gopts.run_type == run_t::benchmark
+                               || gopts.run_type == run_t::benchmark_no_ref);
+    if(is_benchmark) {
+        doc.add("Validation type", get_string(gopts.validation_type));
+    } else {
+        doc.add("Validation type", "None");
+    }
 
     doc.add("Machine Summary","");
     doc.get("Machine Summary")->add("Distributed Processes",A.geom->size);
@@ -359,19 +369,21 @@ void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
                   + c_opt.spmv.get_total_memory_bytes() + c_opt.mg_gs.get_total_memory_bytes()
                   + c_opt.mg_rp.get_total_memory_bytes() + c_opt.vecupd.get_total_memory_bytes()
                   + c_opt.qr_host.get_total_memory_bytes());
-    doc.get(membwstr)->add(" - Raw Ortho  (mxp)", c_opt.ortho.get_total_memory_bytes()
-                                                           /test_data.opt_times[3]/1.0e9);
-    doc.get(membwstr)->add(" - Raw SpMV   (mxp)", c_opt.spmv.get_total_memory_bytes()
-                                                           /test_data.opt_times[4]/1.0e9);
-    doc.get(membwstr)->add(" - Raw MG     (mxp)", optMGBytes/test_data.opt_times[6]/1.0e9);
-    doc.get(membwstr)->add(" -   GS       (mxp)", c_opt.mg_gs.get_total_memory_bytes()
-                                                           /test_data.opt_times[8]/1.0e9);
-    doc.get(membwstr)->add(" -   RestrPro (mxp)", c_opt.mg_rp.get_total_memory_bytes() /
-                                  (test_data.opt_times[9]+test_data.opt_times[10]) / 1.0e9);
-    doc.get(membwstr)->add(" - Raw vecupd (mxp)", c_opt.vecupd.get_total_memory_bytes() /
-                                                       test_data.opt_times[11]/1.0e9);
-    //doc.get(membwstr)->add(" - Raw QRhost (mxp)", c_opt.qr_host.get_total_memory_bytes()/1.0e9);
-    doc.get(membwstr)->add(" - Raw Total  (mxp)", optTotalBytes / test_data.opt_times[0] / 1.0e9);
+    if (test_data.optTotalTime > 0.0) {
+      doc.get(membwstr)->add(" - Raw Ortho  (mxp)", c_opt.ortho.get_total_memory_bytes()
+                                                             /test_data.opt_times[3]/1.0e9);
+      doc.get(membwstr)->add(" - Raw SpMV   (mxp)", c_opt.spmv.get_total_memory_bytes()
+                                                             /test_data.opt_times[4]/1.0e9);
+      doc.get(membwstr)->add(" - Raw MG     (mxp)", optMGBytes/test_data.opt_times[6]/1.0e9);
+      doc.get(membwstr)->add(" -   GS       (mxp)", c_opt.mg_gs.get_total_memory_bytes()
+                                                             /test_data.opt_times[8]/1.0e9);
+      doc.get(membwstr)->add(" -   RestrPro (mxp)", c_opt.mg_rp.get_total_memory_bytes() /
+                                    (test_data.opt_times[9]+test_data.opt_times[10]) / 1.0e9);
+      doc.get(membwstr)->add(" - Raw vecupd (mxp)", c_opt.vecupd.get_total_memory_bytes() /
+                                                         test_data.opt_times[11]/1.0e9);
+      //doc.get(membwstr)->add(" - Raw QRhost (mxp)", c_opt.qr_host.get_total_memory_bytes()/1.0e9);
+      doc.get(membwstr)->add(" - Raw Total  (mxp)", optTotalBytes / test_data.opt_times[0] / 1.0e9);
+    }
 
     const double refTotalBytes = (c_ref.ortho.get_total_memory_bytes()
                   + c_ref.spmv.get_total_memory_bytes() + c_ref.mg_gs.get_total_memory_bytes()
@@ -395,10 +407,12 @@ void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
     doc.get(membwstr)->add("Total for benchmark", optTotalBytes / test_data.opt_times[0] / 1e9 / penalGflops);
 
     doc.add("GFLOP/s Summary","");
-    doc.get("GFLOP/s Summary")->add("Raw Orho", test_data.opt_flops[3]/test_data.opt_times[3]/1.0E9);
-    doc.get("GFLOP/s Summary")->add("Raw SpMV", test_data.opt_flops[2]/test_data.opt_times[4]/1.0E9);
-    doc.get("GFLOP/s Summary")->add("Raw MG",   test_data.opt_flops[1]/test_data.opt_times[6]/1.0E9);
-    doc.get("GFLOP/s Summary")->add("Raw Total",test_data.opt_flops[0]/test_data.opt_times[0]/1.0E9);
+    if (test_data.optTotalTime > 0.0) {
+      doc.get("GFLOP/s Summary")->add("Raw Orho", test_data.opt_flops[3]/test_data.opt_times[3]/1.0E9);
+      doc.get("GFLOP/s Summary")->add("Raw SpMV", test_data.opt_flops[2]/test_data.opt_times[4]/1.0E9);
+      doc.get("GFLOP/s Summary")->add("Raw MG",   test_data.opt_flops[1]/test_data.opt_times[6]/1.0E9);
+      doc.get("GFLOP/s Summary")->add("Raw Total",test_data.opt_flops[0]/test_data.opt_times[0]/1.0E9);
+    }
     if (test_data.refTotalTime > 0.0) {
       doc.get("GFLOP/s Summary")->add(" - Raw Orho  (reference)",test_data.ref_flops[3]/test_data.ref_times[3]/1.0E9);
       doc.get("GFLOP/s Summary")->add(" - Raw SpMV  (reference)",test_data.ref_flops[2]/test_data.ref_times[4]/1.0E9);
@@ -406,15 +420,17 @@ void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
       doc.get("GFLOP/s Summary")->add(" - Raw Total (reference)",test_data.ref_flops[0]/test_data.ref_times[0]/1.0E9);
       doc.get("GFLOP/s Summary")->add(" - Total     (reference)",test_data.refTotalFlops/test_data.refTotalTime/1.0E9);
     }
-    double totalGflops = (test_data.opt_flops[0]/test_data.opt_times[0]/1.0E9) / penalGflops;
-    doc.get("GFLOP/s Summary")->add("Total for benchmark",totalGflops);
+    const double totalGflops = (test_data.opt_flops[0]/test_data.opt_times[0]/1.0E9) / penalGflops;
+    if (test_data.optTotalTime > 0.0) {
+      doc.get("GFLOP/s Summary")->add("Total for benchmark",totalGflops);
+    }
 
     doc.add("User Optimization Overheads","");
     doc.get("User Optimization Overheads")->add("Optimization phase time (sec)", test_data.OptimizeTime);
     doc.get("User Optimization Overheads")->add("Optimization phase time vs reference SpMV+MG time", test_data.OptimizeTime/test_data.SpmvMgTime);
 
     doc.add("Final Summary","");
-    bool isValidRun = (!global_failure);//&& (testsymmetry_data.count_fail==0) 
+    const bool isValidRun = (!global_failure) && is_benchmark;//&& (testsymmetry_data.count_fail==0) 
     if (isValidRun) {
       doc.get("Final Summary")->add("HPGMP result is VALID with a GFLOP/s rating of", totalGflops);
       if (!A.isDotProductOptimized) {
@@ -458,8 +474,8 @@ void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
  * --------------- */
 template
 void ReportResults< SparseMatrix<double>, TestGMRESData<double> >
-  (const SparseMatrix<double>&, int, const TestGMRESData<double>&, int);
+  (const SparseMatrix<double>&, int, const TestGMRESData<double>&, int, const HPGMP_gen_opts&);
 
 template
 void ReportResults< SparseMatrix<float>, TestGMRESData<float> >
-  (const SparseMatrix<float>&, int, const TestGMRESData<float>&, int);
+  (const SparseMatrix<float>&, int, const TestGMRESData<float>&, int, const HPGMP_gen_opts&);

--- a/src/ReportResults.hpp
+++ b/src/ReportResults.hpp
@@ -19,9 +19,9 @@
 #include "SparseMatrix.hpp"
 #include "TestGMRES.hpp"
 
-template<class SparseMatrix_type, class TestGMRESData_type>
+template<class SparseMatrix_type>
 void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
-                   const TestGMRESData_type & testcg_data, int global_failure,
+                   const TestGMRESData& testcg_data, int global_failure,
                    const HPGMP_gen_opts& gopts);
 
 #endif // REPORTRESULTS_HPP

--- a/src/ReportResults.hpp
+++ b/src/ReportResults.hpp
@@ -21,6 +21,7 @@
 
 template<class SparseMatrix_type, class TestGMRESData_type>
 void ReportResults(const SparseMatrix_type & A, int numberOfMgLevels,
-                   const TestGMRESData_type & testcg_data, int global_failure);
+                   const TestGMRESData_type & testcg_data, int global_failure,
+                   const HPGMP_gen_opts& gopts);
 
 #endif // REPORTRESULTS_HPP

--- a/src/SetupProblem.cpp
+++ b/src/SetupProblem.cpp
@@ -46,11 +46,11 @@ using std::endl;
   @see GenerateGeometry
 */
 
-template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type, class TestGMRESData_type>
+template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type>
 void SetupProblem(const char *title, int argc, char ** argv, comm_type comm, DeviceCtx *const dctx,
                   int numberOfMgLevels, bool verbose, Geometry * geom, SparseMatrix_type & A,
                   GMRESData_type & data, SparseMatrix_type2 & A2, GMRESData_type2 & data2,
-                  Vector_type & b, Vector_type & x, TestGMRESData_type & test_data)
+                  Vector_type & b, Vector_type & x, TestGMRESData& test_data)
 {
   HPGMP_Params params;
   HPGMP_Init_Params(title, &argc, &argv, params, comm);
@@ -136,18 +136,18 @@ void SetupProblem(const char *title, int argc, char ** argv, comm_type comm, Dev
 
 // uniform
 template
-void SetupProblem< SparseMatrix<double>, SparseMatrix<double>, GMRESData<double>, GMRESData<double>, Vector<double>, TestGMRESData<double> >
+void SetupProblem< SparseMatrix<double>, SparseMatrix<double>, GMRESData<double>, GMRESData<double>, Vector<double>>
  (const char*, int, char**, comm_type, DeviceCtx*, int, bool, Geometry*, SparseMatrix<double>&, GMRESData<double>&, SparseMatrix<double>&, GMRESData<double>&,
-  Vector<double>&, Vector<double>&, TestGMRESData<double>&);
+  Vector<double>&, Vector<double>&, TestGMRESData&);
 
 template
-void SetupProblem< SparseMatrix<float>, SparseMatrix<float>, GMRESData<float>, GMRESData<float>, Vector<float>, TestGMRESData<float> >
+void SetupProblem< SparseMatrix<float>, SparseMatrix<float>, GMRESData<float>, GMRESData<float>, Vector<float>>
  (const char*, int, char**, comm_type, DeviceCtx*, int, bool, Geometry*, SparseMatrix<float>&, GMRESData<float>&, SparseMatrix<float>&, GMRESData<float>&,
-  Vector<float>&, Vector<float>&, TestGMRESData<float>&);
+  Vector<float>&, Vector<float>&, TestGMRESData&);
 
 // mixed
 template
-void SetupProblem< SparseMatrix<double>, SparseMatrix<float>, GMRESData<double>, GMRESData<float>, Vector<double>, TestGMRESData<double> >
+void SetupProblem< SparseMatrix<double>, SparseMatrix<float>, GMRESData<double>, GMRESData<float>, Vector<double>>
  (const char*, int, char**, comm_type, DeviceCtx*, int, bool, Geometry*, SparseMatrix<double>&, GMRESData<double>&, SparseMatrix<float>&, GMRESData<float>&,
-  Vector<double>&, Vector<double>&, TestGMRESData<double>&);
+  Vector<double>&, Vector<double>&, TestGMRESData&);
 

--- a/src/SetupProblem.hpp
+++ b/src/SetupProblem.hpp
@@ -25,10 +25,11 @@
 
 #include "device_ctx.hpp"
 #include "Geometry.hpp"
+#include "GMRESData.hpp"
 
-template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type, class TestGMRESData_type>
+template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type>
 void SetupProblem(const char *title, int argc, char **argv, comm_type comm, DeviceCtx *dctx, int numberOfMgLevels, bool verbose, Geometry * geom,
                   SparseMatrix_type & A, GMRESData_type & data, SparseMatrix_type2 & A2, GMRESData_type2 & data2,
-                  Vector_type & b, Vector_type & x, TestGMRESData_type & test_data);
+                  Vector_type & b, Vector_type & x, TestGMRESData& test_data);
 
 #endif

--- a/src/TestGMRES.cpp
+++ b/src/TestGMRES.cpp
@@ -66,9 +66,9 @@ inline void ScaleVectorValue(Vector_type & v, local_int_t index, typename Vector
  */
 
 
-template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type, class TestGMRESData_type>
+template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type>
 int TestGMRES(SparseMatrix_type & A, SparseMatrix_type2 & A_lo, GMRESData_type & data, GMRESData_type2 & data_lo,
-              Vector_type & b, Vector_type & x, bool test_diagonal_exaggeration, bool test_noprecond, TestGMRESData_type & test_data) {
+              Vector_type & b, Vector_type & x, bool test_diagonal_exaggeration, bool test_noprecond, TestGMRESData& test_data) {
 
   typedef typename SparseMatrix_type::scalar_type scalar_type;
   typedef typename SparseMatrix_type2::scalar_type scalar_type2;
@@ -128,12 +128,8 @@ int TestGMRES(SparseMatrix_type & A, SparseMatrix_type2 & A_lo, GMRESData_type &
   bool verbose = true;
   scalar_type tolerance = 1.0e-12; // Set tolerance to reasonable value for grossly scaled diagonal terms
 
-  constexpr int num_flops = TestGMRESData_type::n_fl_ops;
-  constexpr int num_times = TestGMRESData_type::n_timed_ops;
-  //test_data.flops = (double*)malloc(num_flops * sizeof(double));
-  //test_data.times = (double*)malloc(num_times * sizeof(double));
-  //test_data.times_comp = (double*)malloc(num_times * sizeof(double));
-  //test_data.times_comm = (double*)malloc(num_times * sizeof(double));
+  constexpr int num_flops = TestGMRESData::n_fl_ops;
+  constexpr int num_times = TestGMRESData::n_timed_ops;
   for (int i=0; i<num_flops; i++) test_data.flops[i] = 0.0;
   for (int i=0; i<num_times; i++) test_data.times[i] = 0.0;
   for (int i=0; i<num_times; i++) test_data.times_comp[i] = 0.0;
@@ -205,19 +201,13 @@ int TestGMRES(SparseMatrix_type & A, SparseMatrix_type2 & A_lo, GMRESData_type &
   ReplaceMatrixDiagonal(A, origDiagA);
   ReplaceMatrixDiagonal(A_lo, origDiagA2);//TODO again, probably funny casting here. 
   CopyVector(origB, b);
-  // Delete vectors
-  //DeleteVector(origDiagA);
-  //DeleteVector(exaggeratedDiagA);
-  //DeleteVector(origDiagA2);
-  //DeleteVector(exagDiagA2);
-  //DeleteVector(origB);
 
   return 0;
 }
 
-template<class SparseMatrix_type, class GMRESData_type, class Vector_type, class TestGMRESData_type>
+template<class SparseMatrix_type, class GMRESData_type, class Vector_type>
 int TestGMRES(SparseMatrix_type & A, GMRESData_type & data, Vector_type & b, Vector_type & x,
-              bool test_diagonal_exaggeration, bool test_noprecond, TestGMRESData_type & test_data) {
+              bool test_diagonal_exaggeration, bool test_noprecond, TestGMRESData& test_data) {
   return TestGMRES(A, A, data, data, b, x, test_diagonal_exaggeration, test_noprecond, test_data);
 }
 
@@ -228,26 +218,26 @@ int TestGMRES(SparseMatrix_type & A, GMRESData_type & data, Vector_type & b, Vec
 
 // uniform
 template
-int TestGMRES< SparseMatrix<double>, GMRESData<double>, Vector<double>, TestGMRESData<double> >
-  (SparseMatrix<double>&, GMRESData<double>&, Vector<double>&, Vector<double>&, bool, bool, TestGMRESData<double>&);
+int TestGMRES< SparseMatrix<double>, GMRESData<double>, Vector<double>>
+  (SparseMatrix<double>&, GMRESData<double>&, Vector<double>&, Vector<double>&, bool, bool, TestGMRESData&);
 
 template
-int TestGMRES< SparseMatrix<float>, GMRESData<float>, Vector<float>, TestGMRESData<float> >
-  (SparseMatrix<float>&, GMRESData<float>&, Vector<float>&, Vector<float>&, bool, bool, TestGMRESData<float>&);
+int TestGMRES< SparseMatrix<float>, GMRESData<float>, Vector<float>>
+  (SparseMatrix<float>&, GMRESData<float>&, Vector<float>&, Vector<float>&, bool, bool, TestGMRESData&);
 
 
 // uniform version
 template
-int TestGMRES< SparseMatrix<double>, SparseMatrix<double>, GMRESData<double>, GMRESData<double>, Vector<double>, TestGMRESData<double> >
-  (SparseMatrix<double>&, SparseMatrix<double>&, GMRESData<double>&, GMRESData<double>&, Vector<double>&, Vector<double>&, bool, bool, TestGMRESData<double>&);
+int TestGMRES< SparseMatrix<double>, SparseMatrix<double>, GMRESData<double>, GMRESData<double>, Vector<double>>
+  (SparseMatrix<double>&, SparseMatrix<double>&, GMRESData<double>&, GMRESData<double>&, Vector<double>&, Vector<double>&, bool, bool, TestGMRESData&);
 
 template
-int TestGMRES< SparseMatrix<float>, SparseMatrix<float>, GMRESData<float>, GMRESData<float>, Vector<float>, TestGMRESData<float> >
-  (SparseMatrix<float>&, SparseMatrix<float>&, GMRESData<float>&, GMRESData<float>&, Vector<float>&, Vector<float>&, bool, bool, TestGMRESData<float>&);
+int TestGMRES< SparseMatrix<float>, SparseMatrix<float>, GMRESData<float>, GMRESData<float>, Vector<float>>
+  (SparseMatrix<float>&, SparseMatrix<float>&, GMRESData<float>&, GMRESData<float>&, Vector<float>&, Vector<float>&, bool, bool, TestGMRESData&);
 
 
 // mixed version
 template
-int TestGMRES< SparseMatrix<double>, SparseMatrix<float>, GMRESData<double>, GMRESData<float>, Vector<double>, TestGMRESData<double> >
-  (SparseMatrix<double>&, SparseMatrix<float>&, GMRESData<double>&, GMRESData<float>&, Vector<double>&, Vector<double>&, bool, bool, TestGMRESData<double>&);
+int TestGMRES< SparseMatrix<double>, SparseMatrix<float>, GMRESData<double>, GMRESData<float>, Vector<double>>
+  (SparseMatrix<double>&, SparseMatrix<float>&, GMRESData<double>&, GMRESData<float>&, Vector<double>&, Vector<double>&, bool, bool, TestGMRESData&);
 

--- a/src/TestGMRES.hpp
+++ b/src/TestGMRES.hpp
@@ -29,13 +29,13 @@
 #include "GMRESData.hpp"
 #include "GMRESData.hpp"
 
-template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type, class TestGMRESData_type>
-extern int TestGMRES(SparseMatrix_type & A, SparseMatrix_type2 & A_lo, GMRESData_type & data, GMRESData_type2 & data_lo,
-                     Vector_type & b, Vector_type & x, bool test_diagonal_exaggeration, bool test_noprecond, TestGMRESData_type & test_data);
+template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type>
+int TestGMRES(SparseMatrix_type & A, SparseMatrix_type2 & A_lo, GMRESData_type & data, GMRESData_type2 & data_lo,
+                     Vector_type & b, Vector_type & x, bool test_diagonal_exaggeration, bool test_noprecond, TestGMRESData& test_data);
 
-template<class SparseMatrix_type, class GMRESData_type, class Vector_type, class TestGMRESData_type>
-extern int TestGMRES(SparseMatrix_type & A, GMRESData_type & data, Vector_type & b, Vector_type & x,
-                     bool test_diagonal_exaggeration, bool test_noprecond, TestGMRESData_type & test_data);
+template<class SparseMatrix_type, class GMRESData_type, class Vector_type>
+int TestGMRES(SparseMatrix_type & A, GMRESData_type & data, Vector_type & b, Vector_type & x,
+                     bool test_diagonal_exaggeration, bool test_noprecond, TestGMRESData& test_data);
 
 #endif  // TESTGMRES_HPP
 

--- a/src/ValidGMRES.cpp
+++ b/src/ValidGMRES.cpp
@@ -51,10 +51,10 @@
  */
 
 
-template<class TestGMRESSData_type, class scalar_type, class scalar_type2, class project_type>
+template<class scalar_type, class scalar_type2, class project_type>
 int ValidGMRES(const int argc, char **argv, const validation_t validation_type, comm_type comm,
-                    DeviceCtx *const dctx,
-                    const int numberOfMgLevels, const bool verbose, TestGMRESSData_type& test_data)
+               DeviceCtx *const dctx, const int numberOfMgLevels, const bool verbose,
+               TestGMRESData& test_data)
 {
   typedef Vector<scalar_type> Vector_type;
   typedef SparseMatrix<scalar_type> SparseMatrix_type;
@@ -84,7 +84,7 @@ int ValidGMRES(const int argc, char **argv, const validation_t validation_type, 
   // Solver Parameters
   const int restart_length = test_data.restart_length;
   const int max_iters = 10000;
-  const scalar_type tolerance = test_data.tolerance;
+  const auto tolerance = static_cast<scalar_type>(test_data.tolerance);
   if (A.geom->rank == 0) {
       std::cout << " Validate GMRES ";
       if(validation_type == validation_t::fullscale) {
@@ -228,12 +228,12 @@ int ValidGMRES(const int argc, char **argv, const validation_t validation_type, 
 
 // uniform version
 template
-int ValidGMRES<TestGMRESData<double>,  double, double, double > (int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData<double>&);
+int ValidGMRES<double, double, double > (int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&);
 
 template
-int ValidGMRES<TestGMRESData<float>, float, float, float > (int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData<float>&);
+int ValidGMRES<float, float, float > (int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&);
 
 // mixed version
 template
-int ValidGMRES<TestGMRESData<double>, double, float, float > (int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData<double>&);
+int ValidGMRES<double, float, float > (int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&);
 

--- a/src/ValidGMRES.hpp
+++ b/src/ValidGMRES.hpp
@@ -29,10 +29,10 @@
 #include "GMRESData.hpp"
 #include "device_ctx.hpp"
 
-template<class TestGMRESData_type, class scalar_type, class scalar_type2,
+template<class scalar_type, class scalar_type2,
          class project_type = scalar_type2>
 int ValidGMRES(int argc, char **argv, validation_t v_type, comm_type comm, DeviceCtx *dctx,
-               int numberOfMgLevels, bool verbose, TestGMRESData_type & testcg_data);
+               int numberOfMgLevels, bool verbose, TestGMRESData& testcg_data);
 
 #endif  // BENCHGMRES_HPP
 

--- a/src/estimate_run_time.cpp
+++ b/src/estimate_run_time.cpp
@@ -1,0 +1,94 @@
+#include "estimate_run_time.hpp"
+
+#include <iostream>
+
+#include "mytimer.hpp"
+#include "GMRES_IR.hpp"
+
+template<typename scalar_type, typename scalar_type2>
+double estimate_run_time(comm_type comm,
+        const SparseMatrix<scalar_type>& A, const SparseMatrix<scalar_type2>& A_lo,
+        GMRESData<scalar_type>& data, GMRESData<scalar_type2>& data_lo,
+        const Vector<scalar_type>& b, Vector<scalar_type>& x, const int max_iters,
+        const int restart_length, const bool verbose)
+{
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
+    TestGMRESData test_data{};
+
+    int niters = 0;
+    scalar_type normr (0.0);
+    scalar_type normr0 (0.0);
+    const scalar_type tolerance = 0.0;
+    const bool precond = true;
+    
+    x.fill_zero();
+    GMRES_IR(A, A_lo, data, data_lo, b, x, restart_length, max_iters, tolerance, niters,
+             normr, normr0, precond, verbose, test_data);
+#ifdef HPGMP_VERBOSE
+    MPI_Barrier(comm);
+    if(A.geom->rank == 0) {
+        std::cout << "estimate_run_time: Completed warmup GMRES-IR run." << std::endl;
+    }
+#endif
+    if (verbose && A.geom->rank==0) {
+      HPGMP_fout << "Warm-up runs" << std::endl;
+    }
+
+    const int timing_calls = 10;
+    double gmresir_run_time = 0;
+    
+    for (int i=0; i < timing_calls; ++i) {
+      x.fill_zero();
+
+      const double time_tic = mytimer();
+      const int ierr = GMRES_IR(A, A_lo, data, data_lo, b, x,
+                                restart_length, max_iters, tolerance, niters, normr, normr0,
+                                precond, verbose, test_data);
+      gmresir_run_time += (mytimer() - time_tic);
+      if(i == 0) {
+        if (A.geom->rank==0) {
+            std::cout << "estimate_run_time: Time taken by first timing solve = "
+                << gmresir_run_time << std::endl;
+            std::cout << "estimate_run_time: Iterations taken by first timing solve = " << niters
+                << std::endl;
+        }
+      }
+    }
+
+    gmresir_run_time /= timing_calls;
+
+    double avg_run_time = 0;
+#ifndef HPGMP_NO_MPI
+    MPI_Allreduce(&gmresir_run_time, &avg_run_time, 1, MPI_DOUBLE, MPI_SUM, comm);
+#else
+    avg_run_time = gmresir_run_time;
+#endif
+    avg_run_time /= A.geom->size;
+
+    HPGMP_RANGE_POP(__FUNCTION__);
+
+    return avg_run_time;
+}
+
+template
+double estimate_run_time(comm_type comm,
+        const SparseMatrix<double>& A, const SparseMatrix<float>& A_lo,
+        GMRESData<double>& data, GMRESData<float>& data_lo,
+        const Vector<double>& b, Vector<double>& x, int max_iters,
+        int restart_length, bool verbose);
+
+template
+double estimate_run_time(comm_type comm,
+        const SparseMatrix<float>& A, const SparseMatrix<float>& A_lo,
+        GMRESData<float>& data, GMRESData<float>& data_lo,
+        const Vector<float>& b, Vector<float>& x, int max_iters,
+        int restart_length, bool verbose);
+
+template
+double estimate_run_time(comm_type comm,
+        const SparseMatrix<double>& A, const SparseMatrix<double>& A_lo,
+        GMRESData<double>& data, GMRESData<double>& data_lo,
+        const Vector<double>& b, Vector<double>& x, int max_iters,
+        int restart_length, bool verbose);
+

--- a/src/estimate_run_time.hpp
+++ b/src/estimate_run_time.hpp
@@ -1,0 +1,18 @@
+#ifndef HPGMP_ESTIMATE_NUM_ITERS_HPP
+#define HPGMP_ESTIMATE_NUM_ITERS_HPP
+
+#include "SparseMatrix.hpp"
+#include "GMRESData.hpp"
+
+/**
+ * Runs GMRES-IR with fixed iteration count a few times to measure
+ * the average time taken per solve.
+ */
+template<typename scalar_type, typename scalar_type2>
+double estimate_run_time(comm_type comm,
+        const SparseMatrix<scalar_type>& A, const SparseMatrix<scalar_type2>& A_lo,
+        GMRESData<scalar_type>& data, GMRESData<scalar_type2>& data_lo,
+        const Vector<scalar_type>& b, Vector<scalar_type>& x, int max_iters,
+        int restart_length, bool verbose);
+
+#endif

--- a/src/hpgmp.hpp
+++ b/src/hpgmp.hpp
@@ -93,6 +93,18 @@ enum class validation_t {
     fullscale
 };
 
+std::string get_string(validation_t val_type);
+
+/// Available types of program run
+enum class run_t {
+    benchmark,             ///< Official benchmark mode (with standard or fullscale validation)
+    benchmark_no_ref,      ///< Official benchmark mode without timed reference run
+    standalone_ref,        ///< Only double precision GMRES without validation
+    standalone_mxp         ///< Only mixed precision GMRES-IR without validation
+};
+
+std::string get_string(run_t run_type);
+
 /// Algorithm and data structure options
 struct hpgmp_options {
     sp_matrix_format_t sp_mat_format;
@@ -101,6 +113,7 @@ struct hpgmp_options {
 
 struct HPGMP_gen_opts {
     validation_t validation_type;
+    run_t run_type;
 };
 
 /*!

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -62,11 +62,12 @@ HPGMP_Init(int * argc_p, char ** *argv_p) {
     const int argc = *argc_p;
     char **argv = *argv_p;
     // Options to be read
-    constexpr int nparams = 1;
-    const std::array<std::string,nparams> cparams = {"--validation_type"};
+    constexpr int nparams = 2;
+    const std::array<std::string,nparams> cparams = {"--validation_type", "--run_type"};
     std::array<std::string,nparams> values;
     // Default values
     values[0] = "standard";
+    values[1] = "benchmark";
 
     // Read cmd line args
     for (int i = 1; i <= argc && argv[i]; ++i) {
@@ -90,6 +91,17 @@ HPGMP_Init(int * argc_p, char ** *argv_p) {
         opts.validation_type = validation_t::fullscale;
     } else {
         throw std::runtime_error("Invalid value for validation_type!");
+    }
+    if(values[1] == "benchmark") {
+        opts.run_type = run_t::benchmark;
+    } else if(values[1] == "benchmark_no_ref") {
+        opts.run_type = run_t::benchmark_no_ref;
+    } else if(values[1] == "standalone_ref") {
+        opts.run_type = run_t::standalone_ref;
+    } else if(values[1] == "standalone_mxp") {
+        opts.run_type = run_t::standalone_mxp;
+    } else {
+        throw std::runtime_error("Invalid value for run_type!");
     }
     return opts;
 }

--- a/src/main_hpgmp.cpp
+++ b/src/main_hpgmp.cpp
@@ -50,7 +50,6 @@ using scalar_type =  double;
 using scalar_type2 = float;
 using project_type = float;
 
-typedef TestGMRESData<scalar_type> TestGMRESData_type;
 typedef Vector<scalar_type> Vector_type;
 typedef SparseMatrix<scalar_type> SparseMatrix_type;
 typedef GMRESData<scalar_type> GMRESData_type;
@@ -126,6 +125,10 @@ int main(int argc, char * argv[]) {
       if(myRank == 0) {
           std::cout << "Running full benchmark mode." << std::endl;
       }
+  } else if(gopts.run_type == run_t::benchmark_no_ref) {
+      if(myRank == 0) {
+          std::cout << "Running benchmark mode without reference (DP) runs." << std::endl;
+      }
   } else if(gopts.run_type == run_t::standalone_ref) {
       if(myRank == 0) {
           std::cout << "Running standalone reference (DP) mode." << std::endl;
@@ -189,7 +192,7 @@ int main(int argc, char * argv[]) {
 #endif
 
   // Use this array for collecting timing information
-  TestGMRESData_type test_data;
+  TestGMRESData test_data;
   //test_data.times = NULL;
   //test_data.flops = NULL;
   test_data.validation_nprocs = sizeValidComm;
@@ -208,7 +211,7 @@ int main(int argc, char * argv[]) {
 
   if (myRank < sizeValidComm && to_validate) {
     TICK();
-    global_failure = ValidGMRES<TestGMRESData_type, scalar_type, scalar_type2, project_type>(
+    global_failure = ValidGMRES<scalar_type, scalar_type2, project_type>(
                            argc, argv, gopts.validation_type, validation_comm, ctx.get(),
                            numberOfMgLevels, verbose, test_data);
     double t_valid{};
@@ -229,7 +232,7 @@ int main(int argc, char * argv[]) {
   {
     const bool runReference = true;
     TICK();
-    BenchGMRES<TestGMRESData_type, scalar_type, scalar_type2, project_type>(argc, argv,
+    BenchGMRES<scalar_type, scalar_type2, project_type>(argc, argv,
             benchmark_comm, ctx.get(), numberOfMgLevels, verbose, global_failure, gopts,
             test_data);
     double t_bench{};

--- a/src/main_hpgmp.cpp
+++ b/src/main_hpgmp.cpp
@@ -122,6 +122,20 @@ int main(int argc, char * argv[]) {
       }
   }
 
+  if(gopts.run_type == run_t::benchmark) {
+      if(myRank == 0) {
+          std::cout << "Running full benchmark mode." << std::endl;
+      }
+  } else if(gopts.run_type == run_t::standalone_ref) {
+      if(myRank == 0) {
+          std::cout << "Running standalone reference (DP) mode." << std::endl;
+      }
+  } else {
+      if(myRank == 0) {
+          std::cout << "Running standalone MxP mode." << std::endl;
+      }
+  }
+
   int ierr = MPI_Comm_set_errhandler(validation_comm, MPI_ERRORS_RETURN);
   if(ierr != MPI_SUCCESS) {
       printf("! Could not set MPI error handler on validation!\n"); fflush(stdout);
@@ -189,8 +203,10 @@ int main(int argc, char * argv[]) {
   const scalar_type tolerance = 1e-9;
   test_data.restart_length = restart_length;
   test_data.tolerance = tolerance;
+  const bool to_validate = (gopts.run_type == run_t::benchmark
+                            || gopts.run_type == run_t::benchmark_no_ref);
 
-  if (myRank < sizeValidComm) {
+  if (myRank < sizeValidComm && to_validate) {
     TICK();
     global_failure = ValidGMRES<TestGMRESData_type, scalar_type, scalar_type2, project_type>(
                            argc, argv, gopts.validation_type, validation_comm, ctx.get(),
@@ -202,6 +218,10 @@ int main(int argc, char * argv[]) {
     }
   }
 
+  if(!to_validate) {
+      test_data.refNumIters = test_data.optNumIters = 1;
+  }
+
 
   /////////////////////
   // Benchmark phase //
@@ -210,7 +230,7 @@ int main(int argc, char * argv[]) {
     const bool runReference = true;
     TICK();
     BenchGMRES<TestGMRESData_type, scalar_type, scalar_type2, project_type>(argc, argv,
-            benchmark_comm, ctx.get(), numberOfMgLevels, verbose, runReference, global_failure,
+            benchmark_comm, ctx.get(), numberOfMgLevels, verbose, global_failure, gopts,
             test_data);
     double t_bench{};
     TOCK(t_bench);
@@ -219,36 +239,6 @@ int main(int argc, char * argv[]) {
                 << std::endl;
     }
   }
-
- 
-#if 0 
-  ////////////////////
-  // Report Results //
-  ////////////////////
-  {
-    // setup problem for reporting (TODO: remove)
-    Geometry * geom = new Geometry;
-
-    SparseMatrix_type A;
-    GMRESData_type data;
-
-    SparseMatrix_type2 A2;
-    GMRESData_type2 data2;
-
-    Vector_type b, x;
-    SetupProblem("report_", argc, argv, benchmark_comm, ctx.get(), numberOfMgLevels, verbose, geom, A, data, A2, data2, b, x, test_data);
-
-
-    // Report results to YAML file
-    ReportResults(A, numberOfMgLevels, test_data, global_failure);
-
-    // Clean up
-    DeleteMatrix(A);
-    DeleteMatrix(A2);
-    DeleteGeometry(*geom);
-    delete geom;
-  }
-#endif
 
   HPGMP_Finalize();
 #ifndef HPGMP_NO_MPI

--- a/src/main_time.cpp
+++ b/src/main_time.cpp
@@ -58,7 +58,6 @@ using std::endl;
 
 typedef double scalar_type;
 //typedef float  scalar_type;
-typedef TestGMRESData<scalar_type> TestGMRESData_type;
 
 typedef Vector<scalar_type> Vector_type;
 typedef SparseMatrix<scalar_type> SparseMatrix_type;
@@ -195,7 +194,7 @@ int main(int argc, char * argv[]) {
   //////////////////////////////
   bool test_diagonal_exaggeration = false;
   bool test_noprecond = true;
-  TestGMRESData_type test_data;
+  TestGMRESData test_data;
 
 #ifdef HPGMP_DEBUG
   t1 = mytimer();
@@ -231,9 +230,6 @@ int main(int argc, char * argv[]) {
   if (rank==0) HPGMP_fout << "Total validation (mixed-precision TestGMRES) execution time in main (sec) = " << mytimer() - t1 << endl;
 #endif
 
-  // free
-  //DeleteMatrix(A2);
-  //DeleteMatrix(A);
   HPGMP_Finalize();
 #ifndef HPGMP_NO_MPI
   MPI_Finalize();

--- a/src/options_strings.cpp
+++ b/src/options_strings.cpp
@@ -1,0 +1,21 @@
+#include "hpgmp.hpp"
+
+std::string get_string(const validation_t val_type) {
+    if(val_type == validation_t::standard) {
+        return "standard";
+    } else {
+        return "fullscale";
+    }
+}
+
+std::string get_string(const run_t run_type) {
+    if(run_type == run_t::benchmark) {
+        return "benchmark";
+    } else if(run_type == run_t::benchmark_no_ref) {
+        return "benchmark_no_ref";
+    } else if(run_type == run_t::standalone_ref) {
+        return "standalone_ref";
+    } else {
+        return "standalone_mxp";
+    }
+}

--- a/unittesting/dot.cpp
+++ b/unittesting/dot.cpp
@@ -51,7 +51,6 @@ using scalar_type =  double;
 using scalar_type2 = float;
 using project_type = float;
 
-typedef TestGMRESData<scalar_type> TestGMRESData_type;
 typedef Vector<scalar_type> Vector_type;
 typedef SparseMatrix<scalar_type> SparseMatrix_type;
 typedef GMRESData<scalar_type> GMRESData_type;
@@ -141,7 +140,7 @@ int main(int argc, char * argv[]) {
 #endif
 
   // Use this array for collecting timing information
-  TestGMRESData_type test_data;
+  TestGMRESData test_data;
   //test_data.times = NULL;
   //test_data.flops = NULL;
   test_data.validation_nprocs = sizeValidComm;
@@ -157,7 +156,7 @@ int main(int argc, char * argv[]) {
   test_data.tolerance = tolerance;
   test_data.restart_length = restart_length;
   if (myRank < sizeValidComm) {
-    global_failure = ValidGMRES<TestGMRESData_type, scalar_type, scalar_type2, project_type>(
+    global_failure = ValidGMRES<scalar_type, scalar_type2, project_type>(
                          argc, argv, validation_t::standard, validation_comm, ctx.get(), numberOfMgLevels, verbose,
                          test_data);
   }

--- a/unittesting/gs_multicolor.cpp
+++ b/unittesting/gs_multicolor.cpp
@@ -32,7 +32,6 @@
 
 typedef double scalar_type;
 //typedef float  scalar_type;
-typedef TestGMRESData<scalar_type> TestGMRESData_type;
 
 typedef Vector<scalar_type> Vector_type;
 typedef SparseMatrix<scalar_type> SparseMatrix_type;

--- a/unittesting/test_spmv.cpp
+++ b/unittesting/test_spmv.cpp
@@ -33,7 +33,6 @@
 
 typedef double scalar_type;
 //typedef float  scalar_type;
-typedef TestGMRESData<scalar_type> TestGMRESData_type;
 
 typedef Vector<scalar_type> Vector_type;
 typedef SparseMatrix<scalar_type> SparseMatrix_type;


### PR DESCRIPTION
We add run modes to the code, selected at run time by the `xhpgmp` flag `--run_type` with 4 possible values:
- `benchmark`: The regular benchmark run with the timed double precision GMRES run in the end. Includes validation. Default.
- `benchmark_no_ref`: Regular benchmark but without double precision GMRES run in the end. Includes validation.
- `standalone_mxp`: Excludes validation, and only performs timed MxP GMRES-IR runs for the specified duration.
- `standalone_ref`: Excludes validation, and only performs 10 repetitions of double precision GMRES.