### PR TITLE
Memory optimizations

### DIFF
--- a/src/GenerateNonsymCoarseProblem.cpp
+++ b/src/GenerateNonsymCoarseProblem.cpp
@@ -118,8 +118,8 @@ void GenerateNonsymCoarseProblem(DeviceCtx *const dctx, const SparseMatrix_type 
   GenerateGeometry(Af.geom->size, Af.geom->rank, Af.geom->numThreads, Af.geom->pz, zlc, zuc,
                    nxc, nyc, nzc, Af.geom->npx, Af.geom->npy, Af.geom->npz, geomc);
 
-  bool init_vect = false;
-  Vector_type * tmp;
+  const bool init_vect = false;
+  Vector_type * tmp{};
   SparseMatrix_type * Ac = new SparseMatrix_type;
   Ac->initialize(geomc, Af.comm, dctx);
   GenerateNonsymProblem(dctx, *Ac, tmp, tmp, tmp, init_vect);

--- a/src/SetupMatrix.cpp
+++ b/src/SetupMatrix.cpp
@@ -47,7 +47,7 @@ void SetupMatrix(DeviceCtx *const dctx, int numberOfMgLevels, SparseMatrix_type 
       std::cout << "Completed generating nonsym problem." << std::endl;
   }
 #endif
-  SetupHalo(A); //TODO: This is currently called in main.. Should it really be called in both places?  Which one? 
+  SetupHalo(A);
 #ifdef HPGMP_VERBOSE
   if(geom->rank == 0) {
       std::cout << "Completed setting up halos." << std::endl;

--- a/src/SetupProblem.cpp
+++ b/src/SetupProblem.cpp
@@ -91,9 +91,6 @@ void SetupProblem(const char *title, int argc, char ** argv, comm_type comm, Dev
   init_vect = false;
   SetupMatrix(dctx, numberOfMgLevels, A2, geom, data2, &b, &x, &xexact, init_vect, comm);
 
-  A.delete_host_global_indices();
-  A2.delete_host_global_indices();
-
   setup_time = mytimer() - setup_time; // Capture total time of setup
 #ifdef HPGMP_VERBOSE
   MPI_Barrier(comm);
@@ -115,6 +112,8 @@ void SetupProblem(const char *title, int argc, char ** argv, comm_type comm, Dev
   }
 #endif
 
+  A.delete_host_data();
+
   // Call user-tunable set up function for A2
   OptimizeProblem(A2, data, b, x, xexact);
   opt_time = mytimer() - opt_time; // Capture total time of setup
@@ -124,6 +123,9 @@ void SetupProblem(const char *title, int argc, char ** argv, comm_type comm, Dev
       std::cout << "   SetupProblem: Optimized LP problem." << std::endl;
   }
 #endif
+
+  A2.delete_host_data();
+
   //times[7] = opt_time;
   test_data.OptimizeTime = opt_time;
 

--- a/src/SetupProblem.cpp
+++ b/src/SetupProblem.cpp
@@ -90,6 +90,10 @@ void SetupProblem(const char *title, int argc, char ** argv, comm_type comm, Dev
   // Setup single-precision A 
   init_vect = false;
   SetupMatrix(dctx, numberOfMgLevels, A2, geom, data2, &b, &x, &xexact, init_vect, comm);
+
+  A.delete_host_global_indices();
+  A2.delete_host_global_indices();
+
   setup_time = mytimer() - setup_time; // Capture total time of setup
 #ifdef HPGMP_VERBOSE
   MPI_Barrier(comm);

--- a/src/SparseMatrix.cpp
+++ b/src/SparseMatrix.cpp
@@ -1,23 +1,44 @@
 #include "SparseMatrix.hpp"
 
 template <class SC>
-void SparseMatrix<SC>::delete_host_global_indices()
+void SparseMatrix<SC>::delete_host_data()
 {
 #ifndef HPGMP_CONTIGUOUS_ARRAYS
     for (local_int_t i = 0; i< localNumberOfRows; ++i) {
         delete [] mtxIndG[i];
         mtxIndG[i] = nullptr;
+        delete [] mtxIndL[i];
+        mtxIndL[i] = nullptr;
+        delete [] matrixValues[i];
+        matrixValues[i] = nullptr;
     }
 #else
-    delete [] mtxIndG[0];
-    mtxIndG[0] = nullptr;
+    if(mtxIndG) {
+        delete [] mtxIndG[0];
+        mtxIndG[0] = nullptr;
+        delete [] mtxIndL[0];
+        mtxIndL[0] = nullptr;
+        delete [] matrixValues[0];
+        matrixValues[0] = nullptr;
+    }
 #endif
     if (mtxIndG) {
         delete [] mtxIndG;
+        delete [] mtxIndL;
+        delete [] matrixValues;
         mtxIndG = nullptr;
+        mtxIndL = nullptr;
+        matrixValues = nullptr;
     }
+    if (matrixDiagonal) {
+        delete [] matrixDiagonal;
+        matrixDiagonal = nullptr;
+    }
+    globalToLocalMap.clear();
+    localToGlobalMap.clear();
+    localToGlobalMap.shrink_to_fit();
     if(Ac) {
-        Ac->delete_host_global_indices();
+        Ac->delete_host_data();
     }
 }
 
@@ -25,21 +46,19 @@ template <class SparseMatrix_type>
 void DeleteMatrix(SparseMatrix_type & A)
 {
 #ifndef HPGMP_CONTIGUOUS_ARRAYS
-    for (local_int_t i = 0; i< A.localNumberOfRows; ++i) {
-        delete [] A.matrixValues[i];
-        delete [] A.mtxIndL[i];
-    }
     if (A.mtxIndG) {
         for (local_int_t i = 0; i< A.localNumberOfRows; ++i) {
             delete [] A.mtxIndG[i];
+            delete [] A.mtxIndL[i];
+            delete [] A.matrixValues[i];
         }
     }
 #else
-    delete [] A.matrixValues[0];
     if (A.mtxIndG) {
         delete [] A.mtxIndG[0];
+        delete [] A.matrixValues[0];
+        delete [] A.mtxIndL[0];
     }
-    delete [] A.mtxIndL[0];
 #endif
     if (A.title)                 delete [] A.title;
     if (A.nonzerosInRow)         delete [] A.nonzerosInRow;

--- a/src/SparseMatrix.cpp
+++ b/src/SparseMatrix.cpp
@@ -1,109 +1,140 @@
 #include "SparseMatrix.hpp"
 
+template <class SC>
+void SparseMatrix<SC>::delete_host_global_indices()
+{
+#ifndef HPGMP_CONTIGUOUS_ARRAYS
+    for (local_int_t i = 0; i< localNumberOfRows; ++i) {
+        delete [] mtxIndG[i];
+        mtxIndG[i] = nullptr;
+    }
+#else
+    delete [] mtxIndG[0];
+    mtxIndG[0] = nullptr;
+#endif
+    if (mtxIndG) {
+        delete [] mtxIndG;
+        mtxIndG = nullptr;
+    }
+    if(Ac) {
+        Ac->delete_host_global_indices();
+    }
+}
+
 template <class SparseMatrix_type>
 void DeleteMatrix(SparseMatrix_type & A)
 {
 #ifndef HPGMP_CONTIGUOUS_ARRAYS
-  for (local_int_t i = 0; i< A.localNumberOfRows; ++i) {
-    delete [] A.matrixValues[i];
-    delete [] A.mtxIndG[i];
-    delete [] A.mtxIndL[i];
-  }
+    for (local_int_t i = 0; i< A.localNumberOfRows; ++i) {
+        delete [] A.matrixValues[i];
+        delete [] A.mtxIndL[i];
+    }
+    if (A.mtxIndG) {
+        for (local_int_t i = 0; i< A.localNumberOfRows; ++i) {
+            delete [] A.mtxIndG[i];
+        }
+    }
 #else
-  delete [] A.matrixValues[0];
-  delete [] A.mtxIndG[0];
-  delete [] A.mtxIndL[0];
+    delete [] A.matrixValues[0];
+    if (A.mtxIndG) {
+        delete [] A.mtxIndG[0];
+    }
+    delete [] A.mtxIndL[0];
 #endif
-  if (A.title)                 delete [] A.title;
-  if (A.nonzerosInRow)         delete [] A.nonzerosInRow;
-  if (A.mtxIndG)               delete [] A.mtxIndG;
-  if (A.mtxIndL)               delete [] A.mtxIndL;
-  if (A.matrixValues)          delete [] A.matrixValues;
-  if (A.matrixDiagonal)        delete [] A.matrixDiagonal;
+    if (A.title)                 delete [] A.title;
+    if (A.nonzerosInRow)         delete [] A.nonzerosInRow;
+    if (A.mtxIndG)               delete [] A.mtxIndG;
+    if (A.mtxIndL)               delete [] A.mtxIndL;
+    if (A.matrixValues)          delete [] A.matrixValues;
+    if (A.matrixDiagonal)        delete [] A.matrixDiagonal;
 
 #ifndef HPGMP_NO_MPI
-  if (A.elementsToSend)        delete [] A.elementsToSend;
-  if (A.neighbors)             delete [] A.neighbors;
-  if (A.receiveLength)         delete [] A.receiveLength;
-  if (A.sendLength)            delete [] A.sendLength;
-  if (A.sendBuffer)            delete [] A.sendBuffer;
+    if (A.elementsToSend)        delete [] A.elementsToSend;
+    if (A.neighbors)             delete [] A.neighbors;
+    if (A.receiveLength)         delete [] A.receiveLength;
+    if (A.sendLength)            delete [] A.sendLength;
+    if (A.sendBuffer)            delete [] A.sendBuffer;
 #endif
 
-  delete A.optimizationData;
+    delete A.optimizationData;
 
-  /*if (A.geom!=0) {
-    DeleteGeometry(*A.geom);
-    delete A.geom;
-    A.geom = 0;
-  }*/
-  if (A.Ac!=0) {
-    // Delete coarse geometry
-    delete A.Ac->geom;
-    // Delete coarse matrix
-    DeleteMatrix(*A.Ac);
-    delete A.Ac; 
-    A.Ac = 0;
-  }
-  if (A.mgData!=0) {
-    // Delete MG data
-    //DeleteMGData(*A.mgData);
-    delete A.mgData;
-    A.mgData = nullptr;
-  }
+    /*if (A.geom!=0) {
+      DeleteGeometry(*A.geom);
+      delete A.geom;
+      A.geom = 0;
+    }*/
+    if (A.Ac!=0) {
+      // Delete coarse geometry
+      delete A.Ac->geom;
+      // Delete coarse matrix
+      DeleteMatrix(*A.Ac);
+      delete A.Ac; 
+      A.Ac = 0;
+    }
+    if (A.mgData!=0) {
+      // Delete MG data
+      //DeleteMGData(*A.mgData);
+      delete A.mgData;
+      A.mgData = nullptr;
+    }
 
-  //DeleteVector (A.workx);
-  //DeleteVector (A.y);
+    //DeleteVector (A.workx);
+    //DeleteVector (A.y);
 
 #ifdef HPGMP_REFERENCE
 #ifdef HPGMP_WITH_CUDA
-  cudaFree (A.d_row_ptr);
-  cudaFree (A.d_col_idx);
-  cudaFree (A.d_nzvals);
-  cudaFree (A.d_sendBuffer);
-  cudaFree (A.d_elementsToSend);
+    cudaFree (A.d_row_ptr);
+    cudaFree (A.d_col_idx);
+    cudaFree (A.d_nzvals);
+    cudaFree (A.d_sendBuffer);
+    cudaFree (A.d_elementsToSend);
 
-  cudaFree (A.d_Lrow_ptr);
-  cudaFree (A.d_Lcol_idx);
-  cudaFree (A.d_Lnzvals);
+    cudaFree (A.d_Lrow_ptr);
+    cudaFree (A.d_Lcol_idx);
+    cudaFree (A.d_Lnzvals);
 
-  cudaFree (A.d_Urow_ptr);
-  cudaFree (A.d_Ucol_idx);
-  cudaFree (A.d_Unzvals);
+    cudaFree (A.d_Urow_ptr);
+    cudaFree (A.d_Ucol_idx);
+    cudaFree (A.d_Unzvals);
 
-  //cusparseDestroyMatDescr(A.descrA);
-  //cusparseDestroyMatDescr(A.descrL);
-  //cusparseDestroyMatDescr(A.descrU);
-  //#if (CUDA_VERSION >= 11000)
-  //cusparseDestroyCsrsv2Info(A.infoL);
-  //#else
-  //cusparseDestroySolveAnalysisInfo(A.infoL);
-  //#endif
+    //cusparseDestroyMatDescr(A.descrA);
+    //cusparseDestroyMatDescr(A.descrL);
+    //cusparseDestroyMatDescr(A.descrU);
+    //#if (CUDA_VERSION >= 11000)
+    //cusparseDestroyCsrsv2Info(A.infoL);
+    //#else
+    //cusparseDestroySolveAnalysisInfo(A.infoL);
+    //#endif
 #elif defined(HPGMP_WITH_HIP)
-  hipFree (A.d_row_ptr);
-  hipFree (A.d_col_idx);
-  hipFree (A.d_nzvals);
-  hipFree (A.d_sendBuffer);
-  hipFree (A.d_elementsToSend);
+    hipFree (A.d_row_ptr);
+    hipFree (A.d_col_idx);
+    hipFree (A.d_nzvals);
+    hipFree (A.d_sendBuffer);
+    hipFree (A.d_elementsToSend);
 
-  hipFree (A.d_Lrow_ptr);
-  hipFree (A.d_Lcol_idx);
-  hipFree (A.d_Lnzvals);
+    hipFree (A.d_Lrow_ptr);
+    hipFree (A.d_Lcol_idx);
+    hipFree (A.d_Lnzvals);
 
-  hipFree (A.d_Urow_ptr);
-  hipFree (A.d_Ucol_idx);
-  hipFree (A.d_Unzvals);
+    hipFree (A.d_Urow_ptr);
+    hipFree (A.d_Ucol_idx);
+    hipFree (A.d_Unzvals);
 
-  //rocsparse_destroy_spmat_descr(A.descrA);
-  //rocsparse_destroy_spmat_descr(A.descrL);
-  //rocsparse_destroy_spmat_descr(A.descrU);
+    //rocsparse_destroy_spmat_descr(A.descrA);
+    //rocsparse_destroy_spmat_descr(A.descrL);
+    //rocsparse_destroy_spmat_descr(A.descrU);
 #endif
 #else // HPGMP_REFERENCE
 
-  A.dctx->device_free(A.perm);
-  delete [] A.sizes;
-  delete [] A.offsets;
+    A.dctx->device_free(A.perm);
+    delete [] A.sizes;
+    delete [] A.offsets;
 #endif // HPGMP_REFERENCE
 }
 
 template void DeleteMatrix(SparseMatrix<double>&);
 template void DeleteMatrix(SparseMatrix<float>&);
+
+template class SparseMatrix<float>;
+template class SparseMatrix<double>;
+

--- a/src/SparseMatrix.hpp
+++ b/src/SparseMatrix.hpp
@@ -51,6 +51,8 @@ public:
       comm = c;
   }
 
+  void delete_host_global_indices();
+
   DeviceCtx *dctx = nullptr;
   char  * title = nullptr; //!< name of the sparse matrix
   const Geometry * geom = nullptr; //!< geometry associated with this matrix

--- a/src/SparseMatrix.hpp
+++ b/src/SparseMatrix.hpp
@@ -51,7 +51,7 @@ public:
       comm = c;
   }
 
-  void delete_host_global_indices();
+  void delete_host_data();
 
   DeviceCtx *dctx = nullptr;
   char  * title = nullptr; //!< name of the sparse matrix

--- a/src/main_time.cpp
+++ b/src/main_time.cpp
@@ -44,7 +44,6 @@ using std::endl;
 #include "CheckAspectRatio.hpp"
 #include "CheckProblem.hpp"
 #include "OptimizeProblem.hpp"
-#include "WriteProblem.hpp"
 #include "mytimer.hpp"
 #include "ComputeSPMV_ref.hpp"
 #include "ComputeMG_ref.hpp"

--- a/src/multicoloring.dev.cpp
+++ b/src/multicoloring.dev.cpp
@@ -221,10 +221,10 @@ __global__ void kernel_jpl(const local_int_t m,
     }
 
     // Get row hash value
-    local_int_t row_hash = hash[row];
+    const local_int_t row_hash = hash[row];
 
-    local_int_t idx = row * BLOCKSIZEX + threadIdx.x;
-    local_int_t col = __ldcg(mtxIndL + idx);
+    const local_int_t idx = row * BLOCKSIZEX + threadIdx.x;
+    const local_int_t col = __ldcg(mtxIndL + idx);
 
     if(col >= 0 && col < m)
     {
@@ -285,9 +285,6 @@ void multicolor_JPL(SparseMatrix<scalar>& A)
 
     A.perm = reinterpret_cast<local_int_t*>(A.dctx->device_alloc(m * sizeof(local_int_t)));
     A.dctx->device_memset(A.perm, -1, sizeof(local_int_t)*m);
-    //if(hipMemset(A.perm, -1, sizeof(local_int_t) * m) != hipSuccess) {
-    //    throw DeviceAPIError("memset failed in multicolor_JPL!");
-    //}
 
     A.nblocks = 0;
 
@@ -323,9 +320,6 @@ void multicolor_JPL(SparseMatrix<scalar>& A)
     {
         blocksize >>= 1;
     }
-
-    //auto d_nonzerosInRow = reinterpret_cast<char*>(A.dctx->device_alloc(m*sizeof(char)));
-    //A.dctx->copy_host_to_device_sync(d_nonzerosInRow, A.nonzerosInRow, m*sizeof(char));
 
     // Run Jones-Plassmann Luby algorithm until all vertices have been colored
     while(colored != m)
@@ -366,7 +360,6 @@ void multicolor_JPL(SparseMatrix<scalar>& A)
     A.ublocks = A.nblocks - 1;
 
     A.dctx->device_free(A.d_rowHash);
-    //A.dctx->device_free(d_nonzerosInRow);
 
     auto tmp_color = reinterpret_cast<local_int_t*>(A.dctx->device_alloc(m*sizeof(local_int_t)));
     auto tmp_perm = reinterpret_cast<local_int_t*>(A.dctx->device_alloc(m*sizeof(local_int_t)));

--- a/src/optimize_problem_ell_rb.cpp
+++ b/src/optimize_problem_ell_rb.cpp
@@ -38,12 +38,6 @@
 #include "permute.hpp"
 #include "multicoloring.hpp"
 
-/** This routine repeats some things from the reference optimization,
- * but deletes any memory allocated in the process.
- */
-template <typename mat_scalar>
-void seemingly_necessary_stuff_from_reference(SparseMatrix<mat_scalar>* M);
-
 /*!
   Optimizes the data structures used for GMRES to increase the
   performance of the benchmark version of the preconditioned GMRES algorithm.
@@ -146,6 +140,7 @@ template
 int OptimizeProblemELL(SparseMatrix<float>& A, GMRESData<double>& data,
                     Vector<double>& b, Vector<double>& x, Vector<double>& xexact);
 
+#if 0
 template <typename SC>
 void seemingly_necessary_stuff_from_reference(SparseMatrix<SC>* M)
 {
@@ -276,6 +271,7 @@ void seemingly_necessary_stuff_from_reference(SparseMatrix<SC>* M)
       curLevelMatrix = curLevelMatrix->Ac;
     } while (curLevelMatrix != nullptr);
 }
+#endif
 
 // Helper function (see OptimizeProblem.hpp for details)
 template<class SparseMatrix_type>


### PR DESCRIPTION
Host arrays of the initial CSR matrix are now deleted after the optimize phase. This enables us to run a local problem of size 384*320^2 instead of 320^3, which leads to about 10-12% better performance across a range of scales.