### PR TITLE
Ginkgo Gauss Seidel halo kernels and projecting in single precision

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -16,4 +16,4 @@ jobs:
         fetch: false
         committer_name: GitHub Actions
         committer_email: actions@github.com
-        message: Apply pre-commmit fixes 
+        message: Apply pre-commit fixes 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if(HPGMP_ENABLE_HIP OR HPGMP_ENABLE_CUDA)
             src/ell_multicolor_gs.dev.cpp
             src/GinkgoMatrix.cpp
             src/GinkgoOptData.cpp
-            src/GinkgoSmoother.cpp
+            src/GinkgoSmoother.dev.cpp
             src/multicoloring.dev.cpp
             src/permute.dev.cpp
             src/prolongation.dev.cpp

--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -416,6 +416,9 @@ template<class SparseMatrixType, class VectorType>
 void test_mg_spmv(comm_type comm, DeviceCtx* const dctx, const Geometry* const geom,
                   const SparseMatrixType& A, TestGMRESData& test_data)
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     const local_int_t nrow = A.localNumberOfRows;
     const local_int_t ncol = A.localNumberOfColumns;
     const bool symmetric   = false;
@@ -467,4 +470,7 @@ void test_mg_spmv(comm_type comm, DeviceCtx* const dctx, const Geometry* const g
         std::cout << "BenchGMRES:  test_mg_spmv: MG = " << mgflops / mgtime / 1e9
                   << " GFLOP/s" << std::endl;
     }
+
+    HPGMP_RANGE_POP(__FUNCTION__);
+
 }

--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -403,13 +403,8 @@ template int BenchGMRES<float, float, float >(int, char**, comm_type, DeviceCtx*
 
 
 // mixed version
-#ifdef HPGMP_WITH_GINKGO_AMP
-template int BenchGMRES<double, float, double >(int, char**, comm_type, DeviceCtx*, int, bool, bool,
-                                                const HPGMP_gen_opts&, TestGMRESData&);
-#else
 template int BenchGMRES<double, float, float >(int, char**, comm_type, DeviceCtx*, int, bool, bool,
                                                const HPGMP_gen_opts&, TestGMRESData&);
-#endif
 
 
 template<class SparseMatrixType, class VectorType>

--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -123,7 +123,7 @@ int BenchGMRES(int argc, char** argv, comm_type comm, DeviceCtx* const dctx, int
 
     Vector_type b, x;
     SetupProblem("bench_", argc, argv, comm, dctx, numberOfMgLevels, verbose, geom, A, data,
-                 A_lo, data_lo, b, x, test_data);
+                 A_lo, data_lo, b, x, test_data, gopts);
     if (geom->rank == 0) {
         std::cout << "BenchGMRES: Set up problem. Running time = " << test_data.runningTime
                   << std::endl;

--- a/src/BenchGMRES.cpp
+++ b/src/BenchGMRES.cpp
@@ -472,5 +472,4 @@ void test_mg_spmv(comm_type comm, DeviceCtx* const dctx, const Geometry* const g
     }
 
     HPGMP_RANGE_POP(__FUNCTION__);
-
 }

--- a/src/ComputeMG.cpp
+++ b/src/ComputeMG.cpp
@@ -89,7 +89,7 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
         auto time_gs_sofar = x.time2_;
         x.time2_           = 0.0;
 
-        HPGMP_RANGE_PUSH("ell_multicolor_gs");
+        HPGMP_RANGE_PUSH("multicolor_gs");
 
         TICK();
 
@@ -125,7 +125,7 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
         x.time2_ = time_gs_sofar;
         TOCK(x.time2_);
 
-        HPGMP_RANGE_POP("ell_multicolor_gs");
+        HPGMP_RANGE_POP("multicolor_gs");
         if (ierr != 0) {
             HPGMP_RANGE_POP(__FUNCTION__);
             return ierr;
@@ -207,7 +207,7 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
         // coarsest grid
         auto time_gs_sofar = x.time2_;
         x.time2_           = 0.0;
-        HPGMP_RANGE_PUSH("ell_multicolor_gs");
+        HPGMP_RANGE_PUSH("multicolor_gs");
         TICK();
 #ifdef HPGMP_WITH_GINKGO
         ierr += ginkgo_multicolor_gs(smoother.get(), mat.get(), &r, &x);
@@ -219,7 +219,7 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
         // restore GS time so far
         x.time2_ = time_gs_sofar;
         TOCK(x.time2_);
-        HPGMP_RANGE_POP("ell_multicolor_gs");
+        HPGMP_RANGE_POP("multicolor_gs");
         //ft.mg_gs.flops[0] += 2*A.totalNumberOfNonzeros;
         ft.mg_gs.add_flops<scalar_type>(2 * A.totalNumberOfNonzeros);
         ft.mg_gs.add_memory_traffic<scalar_type>(A.totalNumberOfNonzeros + 2 * A.totalNumberOfRows);

--- a/src/ComputeMG.cpp
+++ b/src/ComputeMG.cpp
@@ -95,7 +95,7 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
 
         for (int i = 0; i < numberOfPresmootherSteps; ++i) {
             if (i == 0) {
-#ifdef HPGMP_WITH_GINKGO_AMP
+#ifdef HPGMP_WITH_GINKGO
                 ierr += ginkgo_multicolor_gs(smoother.get(), mat.get(), &r, &x);
 #else
                 ierr += ell_multicolor_gs_zero_initial(symmetric, mat.get(), &r, &x);
@@ -109,7 +109,7 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
                     1 + 2 * A.totalNumberOfRows);
                 ft.mg_gs.add_memory_traffic<int>(7.0 / 8 * A.totalNumberOfNonzeros);
             } else {
-#ifdef HPGMP_WITH_GINKGO_AMP
+#ifdef HPGMP_WITH_GINKGO
                 ierr += ginkgo_multicolor_gs(smoother.get(), mat.get(), &r, &x);
 #else
                 ierr += ell_multicolor_gs(symmetric, mat.get(), &r, &x);
@@ -184,7 +184,7 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
 
         const int numberOfPostsmootherSteps = A.mgData->numberOfPostsmootherSteps;
         for (int i = 0; i < numberOfPostsmootherSteps; ++i) {
-#ifdef HPGMP_WITH_GINKGO_AMP
+#ifdef HPGMP_WITH_GINKGO
             ierr += ginkgo_multicolor_gs(smoother.get(), mat.get(), &r, &x);
 #else
             ierr += ell_multicolor_gs(symmetric, mat.get(), &r, &x);
@@ -209,7 +209,7 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
         x.time2_           = 0.0;
         HPGMP_RANGE_PUSH("ell_multicolor_gs");
         TICK();
-#ifdef HPGMP_WITH_GINKGO_AMP
+#ifdef HPGMP_WITH_GINKGO
         ierr += ginkgo_multicolor_gs(smoother.get(), mat.get(), &r, &x);
 #else
         ierr += ell_multicolor_gs(symmetric, mat.get(), &r, &x);

--- a/src/ComputeMG.cpp
+++ b/src/ComputeMG.cpp
@@ -97,9 +97,14 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
             if (i == 0) {
 #ifdef HPGMP_WITH_GINKGO
                 ierr += ginkgo_multicolor_gs(smoother.get(), mat.get(), &r, &x);
+
+                //ft.mg_gs.flops[0] += 2*A.totalNumberOfNonzeros;
+                ft.mg_gs.add_flops<scalar_type>(2 * A.totalNumberOfNonzeros);
+                ft.mg_gs.add_memory_traffic<scalar_type>(A.totalNumberOfNonzeros + 2 * A.totalNumberOfRows);
+                ft.mg_gs.add_memory_traffic<int>(A.totalNumberOfNonzeros);
 #else
                 ierr += ell_multicolor_gs_zero_initial(symmetric, mat.get(), &r, &x);
-#endif
+
                 //ft.mg_gs.flops[0] += A.totalNumberOfNonzeros;
                 ft.mg_gs.add_flops<scalar_type>(A.totalNumberOfNonzeros);
                 // the first color is treated differently:
@@ -108,6 +113,7 @@ int ComputeMG(const SparseMatrix_type& A, const Vector_type& r, Vector_type& x,
                     7.0 / 8 * (A.totalNumberOfNonzeros + A.totalNumberOfRows - 1) / 2 + //
                     1 + 2 * A.totalNumberOfRows);
                 ft.mg_gs.add_memory_traffic<int>(7.0 / 8 * A.totalNumberOfNonzeros);
+#endif
             } else {
 #ifdef HPGMP_WITH_GINKGO
                 ierr += ginkgo_multicolor_gs(smoother.get(), mat.get(), &r, &x);

--- a/src/ComputeSPMV_gpu.cpp
+++ b/src/ComputeSPMV_gpu.cpp
@@ -62,7 +62,9 @@ int ComputeSPMV_ref(const SparseMatrix_type& A, Vector_type& x, Vector_type& y)
 
     assert(x.local_length() >= A.localNumberOfColumns); // Test vector lengths
     assert(y.local_length() >= A.localNumberOfRows);
-    typedef typename SparseMatrix_type::scalar_type scalar_type;
+    typedef typename SparseMatrix_type::local_scalar_type local_scalar_t;
+    typedef typename SparseMatrix_type::halo_scalar_type halo_scalar_t;
+    using scalar_type = local_scalar_t;
 
     const scalar_type one(1.0);
     const scalar_type zero(0.0);
@@ -77,7 +79,7 @@ int ComputeSPMV_ref(const SparseMatrix_type& A, Vector_type& x, Vector_type& y)
 #ifndef HPGMP_NO_MPI
     if (A.geom->size > 1) {
         ExchangeHalo(A, x);
-        //auto elldata = static_cast<const EllOptData<scalar_type,scalar_type>*>(A.optimizationData);
+        //auto elldata = static_cast<const EllOptData<local_scalar_t, local_scalar_t>*>(A.optimizationData);
         //x.update_halos(elldata->mat.get());
     }
 #endif

--- a/src/GMRES.cpp
+++ b/src/GMRES.cpp
@@ -194,7 +194,7 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
 
         //HPGMP_VERBOSE_PRINT("GMRES: Starting restart cycle..");
         while (k <= restart_length && normr / normr0 > tolerance) { // Use ">" to exit when res=zero (continuing will cause NaN)
-            
+
             HPGMP_RANGE_PUSH("GMRES restart cycle");
 
             auto Qkm1 = Q.get_vector(k - 1);

--- a/src/GMRES.cpp
+++ b/src/GMRES.cpp
@@ -107,12 +107,14 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
     Vector_type& p  = data.p; // Direction vector (in MPI mode ncol>=nrow)
     Vector_type& Ap = data.Ap;
 
+    HPGMP_RANGE_PUSH("GMRES setup projection space");
     MultiVector_type Q(nrow, restart_length + 1, A.comm, x.get_device_context());
     SerialDenseMatrix_type H(restart_length + 1, restart_length, x.get_device_context());
     SerialDenseMatrix_type h(restart_length + 1, 1, x.get_device_context());
     SerialDenseMatrix_type t(restart_length + 1, 1, x.get_device_context());
     SerialDenseMatrix_type cs(restart_length + 1, 1, x.get_device_context());
     SerialDenseMatrix_type ss(restart_length + 1, 1, x.get_device_context());
+    HPGMP_RANGE_POP("GMRES setup projection space");
 
     if (!doPreconditioning && A.geom->rank == 0)
         HPGMP_fout << "WARNING: PERFORMING UNPRECONDITIONED ITERATIONS" << std::endl;
@@ -128,6 +130,8 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
     double t_begin      = mytimer(); // Start timing right away
     while (niters <= max_iter && !converged)
     {
+        HPGMP_RANGE_PUSH("GMRES iterations");
+
         // p is of length ncols, copy x to p for sparse MV operation
         // In HIP/Cuda builds, this copies only device buffers.
         CopyVector(x, p);
@@ -190,6 +194,9 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
 
         //HPGMP_VERBOSE_PRINT("GMRES: Starting restart cycle..");
         while (k <= restart_length && normr / normr0 > tolerance) { // Use ">" to exit when res=zero (continuing will cause NaN)
+            
+            HPGMP_RANGE_PUSH("GMRES restart cycle");
+
             auto Qkm1 = Q.get_vector(k - 1);
             auto Qk   = Q.get_vector(k);
 
@@ -339,6 +346,9 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
             }
             niters++;
             k++;
+
+            HPGMP_RANGE_POP("GMRES restart cycle");
+
         } // end of restart-cycle
         // prepare to restart
         if (verbose && A.geom->rank == 0) {
@@ -375,6 +385,9 @@ int GMRES(const SparseMatrix_type& A, GMRESData_type& data, const Vector_type& b
             flops += (itwo * Nrow * (k - ione));
             ctrs.ortho.add_memory_traffic<scalar_type>((A.totalNumberOfRows + 1) * restart_length + 2 * A.totalNumberOfRows);
         }
+
+        HPGMP_RANGE_POP("GMRES iterations");
+
     } // end of outer-loop
 
     //const double flops_gmg = ctrs.mg_gs.get_total_flops() + ctrs.mg_rp.get_total_flops();

--- a/src/GMRESData.cpp
+++ b/src/GMRESData.cpp
@@ -3,4 +3,4 @@
 // Available instantiations
 template class GMRESData<double, double, double>;
 template class GMRESData<float, float, float>;
-template class GMRESData<double, float, double>;
+template class GMRESData<double, float, float>;

--- a/src/GMRESData.hpp
+++ b/src/GMRESData.hpp
@@ -60,11 +60,12 @@ public:
         Ap.initialize(A.localNumberOfRows, A.comm, dctx);
     }
 
-    Vector<local_scalar_t> r; //!< pointer to residual vector
-    Vector<local_scalar_t> z; //!< pointer to preconditioned residual vector
-    Vector<local_scalar_t> p; //!< pointer to direction vector
-    Vector<local_scalar_t> w; //!< pointer to workspace
-    Vector<local_scalar_t> Ap; //!< pointer to Krylov vector
+    using vec_scalar_t = halo_scalar_t;
+    Vector<vec_scalar_t> r; //!< pointer to residual vector
+    Vector<vec_scalar_t> z; //!< pointer to preconditioned residual vector
+    Vector<vec_scalar_t> p; //!< pointer to direction vector
+    Vector<vec_scalar_t> w; //!< pointer to workspace
+    Vector<vec_scalar_t> Ap; //!< pointer to Krylov vector
 };
 
 

--- a/src/GMRES_IR.cpp
+++ b/src/GMRES_IR.cpp
@@ -73,11 +73,9 @@ int GMRES_IR(const SparseMatrix_type& A, const SparseMatrix_type2& A_lo,
     // (working) precision for outer loop
     typedef typename SparseMatrix_type::local_scalar_type scalar_type;
     typedef MultiVector<scalar_type> MultiVector_type;
-    //typedef SerialDenseMatrix<scalar_type> SerialDenseMatrix_type;
     // (lower) precision for inner loop
-    typedef typename SparseMatrix_type2::local_scalar_type scalar_type2;
+    typedef typename SparseMatrix_type2::halo_scalar_type scalar_type2;
     typedef MultiVector<scalar_type2> MultiVector_type2;
-    //typedef SerialDenseMatrix<scalar_type2> SerialDenseMatrix_type;
     typedef Vector<scalar_type2> Vector_type2;
     // (lower) precision for storing projected matrix
     typedef typename GMRESData_type2::project_type project_type;
@@ -633,8 +631,8 @@ template int GMRES_IR< SparseMatrix<double>, SparseMatrix<float>, GMRESData<doub
     TestGMRESData&);
 
 #ifdef HPGMP_WITH_GINKGO_AMP
-template int GMRES_IR< SparseMatrix<double, double>, SparseMatrix<double, float>, GMRESData<double, double, double>, GMRESData<double, float, double>, Vector<double>>(
-    SparseMatrix<double, double> const&, SparseMatrix<double, float> const&, GMRESData<double, double, double>&, GMRESData<double, float, double>&,
+template int GMRES_IR< SparseMatrix<double, double>, SparseMatrix<double, float>, GMRESData<double, double, double>, GMRESData<double, float, float>, Vector<double>>(
+    SparseMatrix<double, double> const&, SparseMatrix<double, float> const&, GMRESData<double, double, double>&, GMRESData<double, float, float>&,
     Vector<double> const&, Vector<double>&, const int, const int, double, int&, double&, double&, bool, bool,
     TestGMRESData&);
 #endif

--- a/src/GMRES_IR.cpp
+++ b/src/GMRES_IR.cpp
@@ -107,6 +107,7 @@ int GMRES_IR(const SparseMatrix_type& A, const SparseMatrix_type2& A_lo,
     //Vector_type2 & p = data_lo.p; // Direction vector (in MPI mode ncol>=nrow)
     //Vector_type2 & Ap = data_lo.Ap;
 
+    HPGMP_RANGE_PUSH("GMRES-IR setup projection space");
     SerialDenseMatrix_type H(restart_length + 1, restart_length, x_hi.get_device_context());
     SerialDenseMatrix_type h(restart_length + 1, 1, x_hi.get_device_context());
     SerialDenseMatrix_type t(restart_length + 1, 1, x_hi.get_device_context());
@@ -122,6 +123,7 @@ int GMRES_IR(const SparseMatrix_type& A, const SparseMatrix_type2& A_lo,
     SerialDenseMatrix_type G(restart_length + 1, 2);
     SerialDenseMatrix_type w(restart_length + 1, 1);
 #endif
+    HPGMP_RANGE_POP("GMRES-IR setup projection space");
 
     // vectors in scalar_type (higher)
     const scalar_type zero_hi(0.0);
@@ -166,6 +168,9 @@ int GMRES_IR(const SparseMatrix_type& A, const SparseMatrix_type2& A_lo,
 
     while (niters <= max_iter && !converged)
     {
+
+        HPGMP_RANGE_PUSH("GMRES-IR iterations");
+
         // > Compute residual vector (higher working precision)
         // p is of length ncols, copy x to p for sparse MV operation
         CopyVector(x_hi, p_hi);
@@ -248,6 +253,9 @@ int GMRES_IR(const SparseMatrix_type& A, const SparseMatrix_type2& A_lo,
         ctrs.qr_host.add_memory_traffic<project_type>(1);
         while (k <= restart_length && normr / normr0 > tolerance && !IS_NAN(normr))
         {
+
+            HPGMP_RANGE_PUSH("GMRES_IR restart cycle");
+
             // Use ">" to exit when res=zero (continuing will cause NaN)
             const auto Qkm1 = Q.get_vector(k - 1);
             auto Qk         = Q.get_vector(k);
@@ -472,6 +480,9 @@ int GMRES_IR(const SparseMatrix_type& A, const SparseMatrix_type2& A_lo,
             }
             niters++;
             k++;
+
+            HPGMP_RANGE_POP("GMRES-IR restart cycle");
+
         } // end of restart-cycle
 
         // prepare to restart. At this point, k == m+1.
@@ -539,6 +550,8 @@ int GMRES_IR(const SparseMatrix_type& A, const SparseMatrix_type2& A_lo,
             ctrs.ortho.add_memory_traffic<scalar_type>(2 * A.totalNumberOfRows);
             ctrs.ortho.add_memory_traffic<project_type>(restart_length);
         }
+
+        HPGMP_RANGE_POP("GMRES-IR iterations");
 
     } // end of outer-loop
 

--- a/src/GenerateNonsymCoarseProblem.cpp
+++ b/src/GenerateNonsymCoarseProblem.cpp
@@ -43,7 +43,7 @@ template<class SparseMatrix_type>
 void GenerateNonsymCoarseProblem(DeviceCtx* const dctx, const SparseMatrix_type& Af)
 {
 
-    typedef typename SparseMatrix_type::scalar_type scalar_type;
+    typedef typename SparseMatrix_type::halo_scalar_type scalar_type;
     typedef Vector<scalar_type> Vector_type;
     typedef MGData<scalar_type> MGData_type;
 

--- a/src/GenerateNonsymCoarseProblem.cpp
+++ b/src/GenerateNonsymCoarseProblem.cpp
@@ -43,6 +43,8 @@ template<class SparseMatrix_type>
 void GenerateNonsymCoarseProblem(DeviceCtx* const dctx, const SparseMatrix_type& Af)
 {
 
+    // Use halo_scalar_type here since, for now, it represents the uniform precision of
+    //   all working vectors inside a restart cycle.
     typedef typename SparseMatrix_type::halo_scalar_type scalar_type;
     typedef Vector<scalar_type> Vector_type;
     typedef MGData<scalar_type> MGData_type;

--- a/src/GenerateNonsymProblem.cpp
+++ b/src/GenerateNonsymProblem.cpp
@@ -77,5 +77,8 @@ template void GenerateNonsymProblem< SparseMatrix<float>, Vector<float> >(
 template void GenerateNonsymProblem< SparseMatrix<double, float>, Vector<double> >(
     DeviceCtx*, SparseMatrix<double, float>&, Vector<double>*, Vector<double>*, Vector<double>*, bool);
 
+template void GenerateNonsymProblem< SparseMatrix<double, float>, Vector<float> >(
+    DeviceCtx*, SparseMatrix<double, float>&, Vector<float>*, Vector<float>*, Vector<float>*, bool);
+
 template void GenerateNonsymProblem< SparseMatrix<float>, Vector<double> >(
     DeviceCtx*, SparseMatrix<float>&, Vector<double>*, Vector<double>*, Vector<double>*, bool);

--- a/src/GenerateNonsymProblem_v1_ref.cpp
+++ b/src/GenerateNonsymProblem_v1_ref.cpp
@@ -294,5 +294,8 @@ template void GenerateNonsymProblem_v1_ref< SparseMatrix<float>, Vector<float> >
 template void GenerateNonsymProblem_v1_ref< SparseMatrix<double, float>, Vector<double> >(
     DeviceCtx*, SparseMatrix<double, float>&, Vector<double>*, Vector<double>*, Vector<double>*, bool);
 
+template void GenerateNonsymProblem_v1_ref< SparseMatrix<double, float>, Vector<float> >(
+    DeviceCtx*, SparseMatrix<double, float>&, Vector<float>*, Vector<float>*, Vector<float>*, bool);
+
 template void GenerateNonsymProblem_v1_ref< SparseMatrix<float>, Vector<double> >(
     DeviceCtx*, SparseMatrix<float>&, Vector<double>*, Vector<double>*, Vector<double>*, bool);

--- a/src/GinkgoInterface.cpp
+++ b/src/GinkgoInterface.cpp
@@ -1,10 +1,12 @@
 #ifdef HPGMP_WITH_GINKGO
+
 #include "GinkgoInterface.hpp"
 
-std::shared_ptr<gko::Executor> create_ginkgo_executor()
+std::shared_ptr<gko::Executor> create_ginkgo_executor(stream_t stream)
 {
 #if defined(HPGMP_WITH_HIP) || defined(HPGMP_WITH_CUDA)
-    return gko_exec_type::create(0, gko_reference_exec_type::create());
+    auto allocator = std::make_shared<gko_allocator_type>();
+    return gko_exec_type::create(0, gko_reference_exec_type::create(), allocator, stream);
 #else
     return gko_exec_type::create();
 #endif

--- a/src/GinkgoInterface.hpp
+++ b/src/GinkgoInterface.hpp
@@ -6,10 +6,10 @@
 
 using gko_reference_exec_type = gko::ReferenceExecutor;
 #ifdef HPGMP_WITH_HIP
-using gko_exec_type = gko::HipExecutor;
+using gko_exec_type      = gko::HipExecutor;
 using gko_allocator_type = gko::HipAllocator;
 #elif HPGMP_WITH_CUDA
-using gko_exec_type = gko::CudaExecutor;
+using gko_exec_type      = gko::CudaExecutor;
 using gko_allocator_type = gko::CudaAllocator;
 #else // CPU
 #ifdef HPGMP_NO_OPENMP

--- a/src/GinkgoInterface.hpp
+++ b/src/GinkgoInterface.hpp
@@ -2,12 +2,15 @@
 #define HPGMP_GINKGO_INTERFACE_HPP
 
 #include <ginkgo/ginkgo.hpp>
+#include "device_ctx.hpp"
 
 using gko_reference_exec_type = gko::ReferenceExecutor;
 #ifdef HPGMP_WITH_HIP
 using gko_exec_type = gko::HipExecutor;
+using gko_allocator_type = gko::HipAllocator;
 #elif HPGMP_WITH_CUDA
 using gko_exec_type = gko::CudaExecutor;
+using gko_allocator_type = gko::CudaAllocator;
 #else // CPU
 #ifdef HPGMP_NO_OPENMP
 using gko_exec_type = gko_reference_exec_type;
@@ -16,6 +19,6 @@ using gko_exec_type = gko::OmpExecutor;
 #endif // HPGMP_NO_OPENMP
 #endif // HPGMP_WITH_HIP or HPGMP_WITH_CUDA
 
-std::shared_ptr<gko::Executor> create_ginkgo_executor();
+std::shared_ptr<gko::Executor> create_ginkgo_executor(stream_t stream);
 
 #endif // HPGMP_GINKGO_INTERFACE

--- a/src/GinkgoMatrix.cpp
+++ b/src/GinkgoMatrix.cpp
@@ -11,7 +11,8 @@ GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<loc
     HPGMP_RANGE_PUSH(__FUNCTION__);
 
     assert(this->ldi_ == this->ldv_);
-    auto gko_exec = create_ginkgo_executor();
+
+    auto gko_exec = create_ginkgo_executor(this->dctx_->get_compute_stream());
     auto ell_mat =
         gko::share(gko_ell_type::create(gko_exec,
                                         gko::dim<2>{static_cast<gko::size_type>(this->local_nrows_),

--- a/src/GinkgoMatrix.cpp
+++ b/src/GinkgoMatrix.cpp
@@ -28,13 +28,31 @@ GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<loc
     if constexpr (std::is_same_v<gko_mat_type, gko_ell_type>)
     {
         gko_mat_ = ell_mat;
+        std::cout << "Using Ginkgo ELL matrix.\n";
     } else if constexpr (std::is_same_v<gko_mat_type, gko_amp_type>)
     {
+        std::ifstream amp_config_file("amp_config.txt");
+        
+        local_scalar_t tol = 1e-8;
+        if (amp_config_file.is_open()) {
+            amp_config_file >> tol;
+            amp_config_file.close();
+        }
+
         auto amp_mat =
-            gko::share(gko_amp_type::build().with_tolerance(1e-8).on(gko_exec)->generate(std::move(ell_mat)));
+            gko::share(gko_amp_type::build().with_tolerance(tol).on(gko_exec)->generate(std::move(ell_mat)));
         gko_mat_ = amp_mat;
-        //std::cout << "Using Ginkgo AMP matrix.\n";
-        //std::cout << "amp_mat->num_precisions:" << amp_mat->num_precisions << "\n";
+
+        std::cout << "Using Ginkgo AMP matrix with tolerance: " << tol << ".\n";
+       
+        auto q = gko_mat_->num_precisions;
+        for (auto k = 0; k < q; k++)
+        {
+            const auto* bin = gko_mat_->get_bin_matrix(k);
+            const auto* bin_ell = static_cast<const gko_ell_type*>(bin);
+            const auto max_nnz_per_row = bin_ell->get_num_stored_elements_per_row();
+            std::cout << "Bin " << k  << ": max_nnz_per_row = " << max_nnz_per_row << "\n";
+        }
     } else
     {
         throw std::runtime_error("Unsupported gko_mat_type in GinkgoMatrix!");

--- a/src/GinkgoMatrix.cpp
+++ b/src/GinkgoMatrix.cpp
@@ -47,6 +47,9 @@ template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 int ginkgo_interior_spmv(const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat,
                          const Vector<vec_scalar_t>* x, Vector<vec_scalar_t>* y)
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     using gko_vec_type = gko::matrix::Dense<vec_scalar_t>;
     auto gko_exec      = mat->get_gko_mat()->get_executor();
     auto gko_x =
@@ -66,6 +69,8 @@ int ginkgo_interior_spmv(const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat,
 
     mat->get_gko_mat()->apply(gko_x, gko_y);
 
+    HPGMP_RANGE_POP(__FUNCTION__);
+
     return 0;
 }
 
@@ -73,6 +78,9 @@ template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 void ginkgo_spmv(const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat,
                  const Vector<vec_scalar_t>* x, Vector<vec_scalar_t>* y)
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     auto dctx = x->get_device_context();
 
     // On halo stream: pack send buffer and copy to host if needed
@@ -89,6 +97,8 @@ void ginkgo_spmv(const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat,
 
     dctx->synchronize_halo_stream();
     dctx->synchronize_compute_stream();
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 }
 
 template<class SparseMatrix_type, class Vector_type>

--- a/src/GinkgoMatrix.cpp
+++ b/src/GinkgoMatrix.cpp
@@ -7,6 +7,9 @@ template<typename local_scalar_t, typename halo_scalar_t>
 GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<local_scalar_t, halo_scalar_t>& A)
     : ELLMatrix<local_scalar_t, halo_scalar_t>(A)
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     assert(this->ldi_ == this->ldv_);
     auto gko_exec = create_ginkgo_executor();
     auto ell_mat =
@@ -36,6 +39,8 @@ GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<loc
     {
         throw std::runtime_error("Unsupported gko_mat_type in GinkgoMatrix!");
     }
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 }
 
 template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>

--- a/src/GinkgoMatrix.cpp
+++ b/src/GinkgoMatrix.cpp
@@ -32,7 +32,7 @@ GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<loc
     } else if constexpr (std::is_same_v<gko_mat_type, gko_amp_type>)
     {
         std::ifstream amp_config_file("amp_config.txt");
-        
+
         local_scalar_t tol = 1e-8;
         if (amp_config_file.is_open()) {
             amp_config_file >> tol;
@@ -44,14 +44,14 @@ GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<loc
         gko_mat_ = amp_mat;
 
         std::cout << "Using Ginkgo AMP matrix with tolerance: " << tol << ".\n";
-       
+
         auto q = gko_mat_->num_precisions;
         for (auto k = 0; k < q; k++)
         {
-            const auto* bin = gko_mat_->get_bin_matrix(k);
-            const auto* bin_ell = static_cast<const gko_ell_type*>(bin);
+            const auto* bin            = gko_mat_->get_bin_matrix(k);
+            const auto* bin_ell        = static_cast<const gko_ell_type*>(bin);
             const auto max_nnz_per_row = bin_ell->get_num_stored_elements_per_row();
-            std::cout << "Bin " << k  << ": max_nnz_per_row = " << max_nnz_per_row << "\n";
+            std::cout << "Bin " << k << ": max_nnz_per_row = " << max_nnz_per_row << "\n";
         }
     } else
     {

--- a/src/GinkgoMatrix.cpp
+++ b/src/GinkgoMatrix.cpp
@@ -15,7 +15,7 @@ GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<loc
     auto ell_mat =
         gko::share(gko_ell_type::create(gko_exec,
                                         gko::dim<2>{static_cast<gko::size_type>(this->local_nrows_),
-                                                    static_cast<gko::size_type>(this->local_ncols_)},
+                                                    static_cast<gko::size_type>(this->local_nrows_)},
                                         std::move(gko::make_array_view(gko_exec,
                                                                        this->ldv_ * this->ell_width_,
                                                                        this->values_)),
@@ -51,14 +51,14 @@ int ginkgo_interior_spmv(const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat,
     auto gko_exec      = mat->get_gko_mat()->get_executor();
     auto gko_x =
         gko_vec_type::create_const(gko_exec,
-                                   gko::dim<2>{static_cast<gko::size_type>(x->local_length()), 1},
+                                   gko::dim<2>{static_cast<gko::size_type>(mat->get_local_num_rows()), 1},
                                    gko::make_const_array_view(gko_exec,
                                                               x->local_length(),
                                                               x->d_values()),
                                    1);
     auto gko_y =
         gko_vec_type::create(gko_exec,
-                             gko::dim<2>{static_cast<gko::size_type>(y->local_length()), 1},
+                             gko::dim<2>{static_cast<gko::size_type>(mat->get_local_num_rows()), 1},
                              std::move(gko::make_array_view(gko_exec,
                                                             y->local_length(),
                                                             y->d_values())),

--- a/src/GinkgoMatrix.cpp
+++ b/src/GinkgoMatrix.cpp
@@ -4,7 +4,8 @@
 #include "Profiling.hpp"
 
 template<typename local_scalar_t, typename halo_scalar_t>
-GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<local_scalar_t, halo_scalar_t>& A)
+GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<local_scalar_t, halo_scalar_t>& A,
+                                                          const HPGMP_gen_opts& gopts)
     : ELLMatrix<local_scalar_t, halo_scalar_t>(A)
 {
 
@@ -32,19 +33,11 @@ GinkgoMatrix<local_scalar_t, halo_scalar_t>::GinkgoMatrix(const SparseMatrix<loc
         std::cout << "Using Ginkgo ELL matrix.\n";
     } else if constexpr (std::is_same_v<gko_mat_type, gko_amp_type>)
     {
-        std::ifstream amp_config_file("amp_config.txt");
-
-        local_scalar_t tol = 1e-8;
-        if (amp_config_file.is_open()) {
-            amp_config_file >> tol;
-            amp_config_file.close();
-        }
-
         auto amp_mat =
-            gko::share(gko_amp_type::build().with_tolerance(tol).on(gko_exec)->generate(std::move(ell_mat)));
+            gko::share(gko_amp_type::build().with_tolerance(gopts.amp_tol).on(gko_exec)->generate(std::move(ell_mat)));
         gko_mat_ = amp_mat;
 
-        std::cout << "Using Ginkgo AMP matrix with tolerance: " << tol << ".\n";
+        std::cout << "Using Ginkgo AMP matrix with tolerance: " << gopts.amp_tol << ".\n";
 
         auto q = gko_mat_->num_precisions;
         for (auto k = 0; k < q; k++)

--- a/src/GinkgoMatrix.hpp
+++ b/src/GinkgoMatrix.hpp
@@ -47,7 +47,7 @@ public:
      * Initialize this matrix with a conversion of a HPGMP SparseMatrix, with
      * ELLMatrix as an intermediary step.
      */
-    GinkgoMatrix(const SparseMatrix<local_scalar_t, halo_scalar_t>& A);
+    GinkgoMatrix(const SparseMatrix<local_scalar_t, halo_scalar_t>& A, const HPGMP_gen_opts& gopts);
 
     ~GinkgoMatrix()
     { }

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -71,6 +71,9 @@ __launch_bounds__(BLOCKSIZE)
 template<typename local_scalar_t, typename halo_scalar_t>
 GinkgoSmoother<local_scalar_t, halo_scalar_t>::GinkgoSmoother(const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat)
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     auto gko_mat    = mat->get_gko_mat();
     auto gko_exec   = gko_mat->get_executor();
     auto color_ptrs = mat->get_independent_set_offsets();
@@ -86,6 +89,8 @@ GinkgoSmoother<local_scalar_t, halo_scalar_t>::GinkgoSmoother(const GinkgoMatrix
     smoother_ = gko::share(smoother_factory->generate(gko_mat));
 
     //std::cout << "Using Ginkgo (FwdGaussSeidel) smoother.\n";
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 }
 
 template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
@@ -121,6 +126,8 @@ int ginkgo_multicolor_gs(const GinkgoSmoother<local_scalar_t, halo_scalar_t>* in
                          const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat,
                          const Vector<vec_scalar_t>* r, Vector<vec_scalar_t>* x)
 {
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     assert(x->local_length() == mat->get_local_num_cols());
     auto dctx            = mat->get_device_context();
     auto stream_interior = dctx->get_compute_stream();
@@ -152,6 +159,8 @@ int ginkgo_multicolor_gs(const GinkgoSmoother<local_scalar_t, halo_scalar_t>* in
 
     dctx->synchronize_compute_stream();
     dctx->synchronize_halo_stream();
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 
     return 0;
 }

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -31,16 +31,16 @@ template<unsigned int BLOCKSIZE, unsigned int WIDTH,
          typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_fgs_halo(const local_int_t m,
-                                      const local_int_t n,
-                                      const local_int_t block_nrow,
-                                      const int ldi, const int ldv,
-                                      const local_int_t* halo_row_ind,
-                                      const local_int_t* halo_col_ind,
-                                      const halo_scalar_t* halo_val,
-                                      const local_scalar_t* inv_diag,
-                                      const local_int_t* perm,
-                                      const vec_scalar_t* x,
-                                      vec_scalar_t* y)
+                                    const local_int_t n,
+                                    const local_int_t block_nrow,
+                                    const int ldi, const int ldv,
+                                    const local_int_t* halo_row_ind,
+                                    const local_int_t* halo_col_ind,
+                                    const halo_scalar_t* halo_val,
+                                    const local_scalar_t* inv_diag,
+                                    const local_int_t* perm,
+                                    const vec_scalar_t* x,
+                                    vec_scalar_t* y)
 {
     const local_int_t row = blockIdx.x * BLOCKSIZE + threadIdx.x;
     if (row >= m) {

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -79,6 +79,7 @@ GinkgoSmoother<local_scalar_t, halo_scalar_t>::GinkgoSmoother(const GinkgoMatrix
     auto smoother_factory = smoother_type::build()
                                 .with_criteria(gko::stop::Iteration::build().with_max_iters(1u))
                                 .with_color_ptrs(color_ptrs_vector)
+                                .with_init_guess_mode(gko::solver::initial_guess_mode::provided)
                                 .on(gko_exec);
 
     smoother_ = gko::share(smoother_factory->generate(gko_mat));

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -16,7 +16,6 @@
                stream_interior>>>(                                                     \
                 mat->get_num_halo_rows(),                                              \
                 mat->get_local_num_cols(),                                             \
-                mat->get_independent_set_sizes()[i],                                   \
                 mat->get_halo_ld_indices(), mat->get_halo_ld_values(),                 \
                 mat->get_halo_row_indices(),                                           \
                 mat->get_halo_col_idxs(),                                              \
@@ -32,7 +31,6 @@ template<unsigned int BLOCKSIZE, unsigned int WIDTH,
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_fgs_halo(const local_int_t m,
                                     const local_int_t n,
-                                    const local_int_t block_nrow,
                                     const int ldi, const int ldv,
                                     const local_int_t* halo_row_ind,
                                     const local_int_t* halo_col_ind,
@@ -49,9 +47,6 @@ __launch_bounds__(BLOCKSIZE)
 
     const local_int_t halo_idx = __ldcg(halo_row_ind + row);
     const local_int_t perm_idx = perm[halo_idx];
-    if (perm_idx >= block_nrow) {
-        return;
-    }
 
     vec_scalar_t sum = 0.0;
 
@@ -148,11 +143,8 @@ int ginkgo_multicolor_gs(const GinkgoSmoother<local_scalar_t, halo_scalar_t>* in
     if (mat->get_geometry()->size > 1)
     {
         x->update_halos_finalize(mat);
-        for (local_int_t i; i < mat->get_num_independent_sets(); ++i) // all colors
-        {
-            if (mat->get_ell_width() == 27) {
-                LAUNCH_FGS_HALO(256, 27);
-            }
+        if (mat->get_ell_width() == 27) {
+            LAUNCH_FGS_HALO(256, 27); // all colors
         }
     }
 #endif

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -139,7 +139,6 @@ int ginkgo_multicolor_gs(const GinkgoSmoother<local_scalar_t, halo_scalar_t>* in
     if (mat->get_geometry()->size > 1)
     {
         x->update_halos_pack_send_buffer(mat);
-        x->update_halos_send_receive(mat);
     }
 #endif
 
@@ -148,6 +147,7 @@ int ginkgo_multicolor_gs(const GinkgoSmoother<local_scalar_t, halo_scalar_t>* in
 #ifndef HPGMP_NO_MPI
     if (mat->get_geometry()->size > 1)
     {
+        x->update_halos_send_receive(mat);
         x->update_halos_finalize(mat);
         if (mat->get_ell_width() == 27) {
             LAUNCH_FGS_HALO(256, 27); // all colors

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -2,6 +2,72 @@
 
 #include "GinkgoOptData.hpp"
 
+#include "kernel_helpers.hpp.inc"
+
+#define LAUNCH_FGS_HALO(blocksize, width)                                              \
+    {                                                                                  \
+        dim3 blocks((mat->get_num_halo_rows() - 1) / blocksize + 1);                   \
+        dim3 threads(blocksize);                                                       \
+                                                                                       \
+        kernel_fgs_halo<blocksize, width, local_scalar_t, halo_scalar_t, vec_scalar_t> \
+            <<<blocks,                                                                 \
+               threads,                                                                \
+               0,                                                                      \
+               stream_interior>>>(                                                     \
+                mat->get_num_halo_rows(),                                              \
+                mat->get_local_num_cols(),                                             \
+                mat->get_independent_set_sizes()[i],                                   \
+                mat->get_halo_ld_indices(), mat->get_halo_ld_values(),                 \
+                mat->get_halo_row_indices(),                                           \
+                mat->get_halo_col_idxs(),                                              \
+                mat->get_halo_values(),                                                \
+                mat->get_inverse_diagonal(),                                           \
+                mat->get_reordering_permutation(),                                     \
+                r->d_values(),                                                         \
+                x->d_values());                                                        \
+    }
+
+template<unsigned int BLOCKSIZE, unsigned int WIDTH,
+         typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
+__launch_bounds__(BLOCKSIZE)
+    __global__ void kernel_fgs_halo(const local_int_t m,
+                                      const local_int_t n,
+                                      const local_int_t block_nrow,
+                                      const int ldi, const int ldv,
+                                      const local_int_t* halo_row_ind,
+                                      const local_int_t* halo_col_ind,
+                                      const halo_scalar_t* halo_val,
+                                      const local_scalar_t* inv_diag,
+                                      const local_int_t* perm,
+                                      const vec_scalar_t* x,
+                                      vec_scalar_t* y)
+{
+    const local_int_t row = blockIdx.x * BLOCKSIZE + threadIdx.x;
+    if (row >= m) {
+        return;
+    }
+
+    const local_int_t halo_idx = __ldcg(halo_row_ind + row);
+    const local_int_t perm_idx = perm[halo_idx];
+    if (perm_idx >= block_nrow) {
+        return;
+    }
+
+    vec_scalar_t sum = 0.0;
+
+#pragma unroll
+    for (local_int_t p = 0; p < WIDTH; ++p)
+    {
+        const local_int_t col = __ldcg(halo_col_ind + row + p * ldi);
+
+        if (col >= 0 && col < n) {
+            sum = fma(-static_cast<vec_scalar_t>(__ldcg(halo_val + row + p * ldv)),
+                      y[col], sum);
+        }
+    }
+    y[perm_idx] = fma(sum, static_cast<vec_scalar_t>(inv_diag[halo_idx]), y[perm_idx]);
+}
+
 template<typename local_scalar_t, typename halo_scalar_t>
 GinkgoSmoother<local_scalar_t, halo_scalar_t>::GinkgoSmoother(const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat)
 {
@@ -55,7 +121,38 @@ int ginkgo_multicolor_gs(const GinkgoSmoother<local_scalar_t, halo_scalar_t>* in
                          const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat,
                          const Vector<vec_scalar_t>* r, Vector<vec_scalar_t>* x)
 {
-    int ierr = ginkgo_multicolor_gs_interior(interior_smoother, mat, r, x);
+    assert(x->local_length() == mat->get_local_num_cols());
+    auto dctx            = mat->get_device_context();
+    auto stream_interior = dctx->get_compute_stream();
+
+    local_int_t i = 0;
+
+#ifndef HPGMP_NO_MPI
+    if (mat->get_geometry()->size > 1)
+    {
+        x->update_halos_pack_send_buffer(mat);
+    }
+#endif
+
+    ginkgo_multicolor_gs_interior(interior_smoother, mat, r, x); // all independent row blocks
+                                                                 
+#ifndef HPGMP_NO_MPI
+    if (mat->get_geometry()->size > 1)
+    {
+        x->update_halos_send_receive(mat);
+        x->update_halos_finalize(mat);
+        for (local_int_t i; i < mat->get_num_independent_sets(); ++i) // all colors
+        {
+            if (mat->get_ell_width() == 27) {
+                LAUNCH_FGS_HALO(256, 27);
+            }
+        }
+    }
+#endif
+
+    dctx->synchronize_compute_stream();
+    dctx->synchronize_halo_stream();
+
     return 0;
 }
 

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -84,7 +84,7 @@ GinkgoSmoother<local_scalar_t, halo_scalar_t>::GinkgoSmoother(const GinkgoMatrix
 
     smoother_ = gko::share(smoother_factory->generate(gko_mat));
 
-    //std::cout << "Using Ginkgo (FwdGaussSeidel) smoother.\n";
+    std::cout << "Using Ginkgo (FwdGaussSeidel) smoother.\n";
 
     HPGMP_RANGE_POP(__FUNCTION__);
 }

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -103,14 +103,14 @@ int ginkgo_multicolor_gs_interior(const GinkgoSmoother<local_scalar_t, halo_scal
     auto gko_exec      = mat->get_gko_mat()->get_executor();
     auto gko_r =
         gko_vec_type::create_const(gko_exec,
-                                   gko::dim<2>{static_cast<gko::size_type>(r->local_length()), 1},
+                                   gko::dim<2>{static_cast<gko::size_type>(mat->get_local_num_rows()), 1},
                                    gko::make_const_array_view(gko_exec,
                                                               r->local_length(),
                                                               r->d_values()),
                                    1);
     auto gko_x =
         gko_vec_type::create(gko_exec,
-                             gko::dim<2>{static_cast<gko::size_type>(x->local_length()), 1},
+                             gko::dim<2>{static_cast<gko::size_type>(mat->get_local_num_rows()), 1},
                              std::move(gko::make_array_view(gko_exec,
                                                             x->local_length(),
                                                             x->d_values())),

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -93,6 +93,9 @@ int ginkgo_multicolor_gs_interior(const GinkgoSmoother<local_scalar_t, halo_scal
                                   const GinkgoMatrix<local_scalar_t, halo_scalar_t>* mat,
                                   const Vector<vec_scalar_t>* r, Vector<vec_scalar_t>* x)
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     using gko_vec_type = gko::matrix::Dense<vec_scalar_t>;
     auto gko_smoother  = interior_smoother->get_smoother();
     auto gko_exec      = mat->get_gko_mat()->get_executor();
@@ -112,6 +115,8 @@ int ginkgo_multicolor_gs_interior(const GinkgoSmoother<local_scalar_t, halo_scal
                              1);
 
     gko_smoother->apply(gko_r, gko_x);
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 
     return 0;
 }

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -135,7 +135,7 @@ int ginkgo_multicolor_gs(const GinkgoSmoother<local_scalar_t, halo_scalar_t>* in
 #endif
 
     ginkgo_multicolor_gs_interior(interior_smoother, mat, r, x); // all independent row blocks
-                                                                 
+
 #ifndef HPGMP_NO_MPI
     if (mat->get_geometry()->size > 1)
     {

--- a/src/GinkgoSmoother.dev.cpp
+++ b/src/GinkgoSmoother.dev.cpp
@@ -60,7 +60,7 @@ __launch_bounds__(BLOCKSIZE)
     {
         const local_int_t col = __ldcg(halo_col_ind + row + p * ldi);
 
-        if (col >= 0 && col < n) {
+        if (col >= m && col < n) {
             sum = fma(-static_cast<vec_scalar_t>(__ldcg(halo_val + row + p * ldv)),
                       y[col], sum);
         }
@@ -138,6 +138,7 @@ int ginkgo_multicolor_gs(const GinkgoSmoother<local_scalar_t, halo_scalar_t>* in
     if (mat->get_geometry()->size > 1)
     {
         x->update_halos_pack_send_buffer(mat);
+        x->update_halos_send_receive(mat);
     }
 #endif
 
@@ -146,7 +147,6 @@ int ginkgo_multicolor_gs(const GinkgoSmoother<local_scalar_t, halo_scalar_t>* in
 #ifndef HPGMP_NO_MPI
     if (mat->get_geometry()->size > 1)
     {
-        x->update_halos_send_receive(mat);
         x->update_halos_finalize(mat);
         for (local_int_t i; i < mat->get_num_independent_sets(); ++i) // all colors
         {

--- a/src/OptimizeProblem.cpp
+++ b/src/OptimizeProblem.cpp
@@ -5,42 +5,37 @@
 
 #include "OptimizeProblem.hpp"
 
-#include "DataTypes.hpp"
-#include "SparseMatrix.hpp"
-#include "Vector.hpp"
-#include "GMRESData.hpp"
-
 template<typename local_scalar_type, typename halo_scalar_t, typename GMRESData_type, typename vec_scalar_t>
 int OptimizeProblemELL(SparseMatrix<local_scalar_type, halo_scalar_t>& A, GMRESData_type& data,
-                       Vector<vec_scalar_t>& b, Vector<vec_scalar_t>& x, Vector<vec_scalar_t>& xexact);
+                       Vector<vec_scalar_t>& b, Vector<vec_scalar_t>& x, Vector<vec_scalar_t>& xexact, const HPGMP_gen_opts& gopts);
 
 template<typename SparseMatrix_type, typename GMRESData_type, typename Vector_type>
 int OptimizeProblem_ref(SparseMatrix_type& A, GMRESData_type& data,
-                        Vector_type& b, Vector_type& x, Vector_type& xexact);
+                        Vector_type& b, Vector_type& x, Vector_type& xexact, const HPGMP_gen_opts& gopts);
 
 template<class SparseMatrix_type, class GMRESData_type, class Vector_type>
 int OptimizeProblem(SparseMatrix_type& A, GMRESData_type& data, Vector_type& b, Vector_type& x,
-                    Vector_type& xexact)
+                    Vector_type& xexact, const HPGMP_gen_opts& gopts)
 {
 #ifdef HPGMP_REFERENCE
-    OptimizeProblem_ref(A, data, b, x, xexact);
+    OptimizeProblem_ref(A, data, b, x, xexact, gopts);
 #else
-    OptimizeProblemELL(A, data, b, x, xexact);
+    OptimizeProblemELL(A, data, b, x, xexact, gopts);
 #endif
     return 0;
 }
 
 template int OptimizeProblem(
     SparseMatrix<double>&, GMRESData<double, double, double>&, Vector<double>&, Vector<double>&,
-    Vector<double>&);
+    Vector<double>&, const HPGMP_gen_opts&);
 template int OptimizeProblem(
     SparseMatrix<float>&, GMRESData<float, float, float>&, Vector<float>&, Vector<float>&,
-    Vector<float>&);
+    Vector<float>&, const HPGMP_gen_opts&);
 template int OptimizeProblem(
     SparseMatrix<float>&, GMRESData<double, double, double>&, Vector<double>&, Vector<double>&,
-    Vector<double>&);
+    Vector<double>&, const HPGMP_gen_opts&);
 #ifdef HPGMP_WITH_GINKGO_AMP
 template int OptimizeProblem(
     SparseMatrix<double, float>&, GMRESData<double, double, double>&, Vector<double>&, Vector<double>&,
-    Vector<double>&);
+    Vector<double>&, const HPGMP_gen_opts&);
 #endif

--- a/src/OptimizeProblem.hpp
+++ b/src/OptimizeProblem.hpp
@@ -17,9 +17,14 @@
 #ifndef OPTIMIZEPROBLEM_HPP
 #define OPTIMIZEPROBLEM_HPP
 
+#include "DataTypes.hpp"
+#include "SparseMatrix.hpp"
+#include "Vector.hpp"
+#include "GMRESData.hpp"
+
 template<class SparseMatrix_type, class GMRESData_type, class Vector_type>
 int OptimizeProblem(SparseMatrix_type& A, GMRESData_type& data, Vector_type& b, Vector_type& x,
-                    Vector_type& xexact);
+                    Vector_type& xexact, const HPGMP_gen_opts& gopts);
 
 /** @brief Helper function that reports memory usage of the optimization proces.
  *
@@ -32,6 +37,6 @@ int OptimizeProblem(SparseMatrix_type& A, GMRESData_type& data, Vector_type& b, 
  */
 
 template<class SparseMatrix_type>
-double OptimizeProblemMemoryUse(const SparseMatrix_type& A);
+double OptimizeProblemMemoryUse(const SparseMatrix_type& A, const HPGMP_gen_opts& gopts);
 
 #endif // OPTIMIZEPROBLEM_HPP

--- a/src/ReportResults.cpp
+++ b/src/ReportResults.cpp
@@ -129,7 +129,7 @@ void ReportResults(const SparseMatrix_type& A, int numberOfMgLevels,
         fnbytesPerLevel[0] = fnbytes;
 
         // Benchmarker-provided model for OptimizeProblem.cpp
-        double fnbytes_OptimizedProblem = OptimizeProblemMemoryUse(A);
+        double fnbytes_OptimizedProblem = OptimizeProblemMemoryUse(A, gopts);
         fnbytes += fnbytes_OptimizedProblem;
 
         Af = A.Ac;
@@ -182,6 +182,9 @@ void ReportResults(const SparseMatrix_type& A, int numberOfMgLevels,
         } else {
             doc.add("Validation type", "None");
         }
+#ifdef HPGMP_WITH_GINKGO_AMP
+        doc.add("AMP tolerance", gopts.amp_tol);
+#endif
 
         doc.add("Machine Summary", "");
         doc.get("Machine Summary")->add("Distributed Processes", A.geom->size);

--- a/src/SetupMatrix.cpp
+++ b/src/SetupMatrix.cpp
@@ -40,6 +40,8 @@ void SetupMatrix(DeviceCtx* const dctx, int numberOfMgLevels, SparseMatrix_type&
                  Vector_type* b, Vector_type* x, Vector_type* xexact, bool init_vect, comm_type comm)
 {
 
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     A.initialize(geom, comm, dctx);
 
     GenerateNonsymProblem(dctx, A, b, x, xexact, init_vect);
@@ -87,6 +89,8 @@ void SetupMatrix(DeviceCtx* const dctx, int numberOfMgLevels, SparseMatrix_type&
     #endif */
 
     data.initialize(A, dctx);
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 }
 
 /* --------------- *

--- a/src/SetupMatrix.cpp
+++ b/src/SetupMatrix.cpp
@@ -110,9 +110,9 @@ template void SetupMatrix< SparseMatrix<float>, GMRESData<float, float, float>, 
 
 
 // mixed
-template void SetupMatrix< SparseMatrix<double, float>, GMRESData<double, float, double>, class Vector<double> >(
+template void SetupMatrix< SparseMatrix<double, float>, GMRESData<double, float, float>, class Vector<double> >(
     DeviceCtx* dctx, int numberOfMgLevels, SparseMatrix<double, float>& A, Geometry* geom,
-    GMRESData<double, float, double>& data, Vector<double>* b, Vector<double>* x, Vector<double>* xexact,
+    GMRESData<double, float, float>& data, Vector<double>* b, Vector<double>* x, Vector<double>* xexact,
     bool init_vect, comm_type comm);
 
 template void SetupMatrix< SparseMatrix<float>, GMRESData<float, float, float>, class Vector<double> >(

--- a/src/SetupProblem.cpp
+++ b/src/SetupProblem.cpp
@@ -50,7 +50,7 @@ template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type
 void SetupProblem(const char* title, int argc, char** argv, comm_type comm, DeviceCtx* const dctx,
                   int numberOfMgLevels, bool verbose, Geometry* geom, SparseMatrix_type& A,
                   GMRESData_type& data, SparseMatrix_type2& A2, GMRESData_type2& data2,
-                  Vector_type& b, Vector_type& x, TestGMRESData& test_data)
+                  Vector_type& b, Vector_type& x, TestGMRESData& test_data, const HPGMP_gen_opts& gopts)
 {
     HPGMP_RANGE_PUSH(__FUNCTION__);
 
@@ -107,7 +107,7 @@ void SetupProblem(const char* title, int argc, char** argv, comm_type comm, Devi
     //////////////////////////////////////////////////////////
     // Call user-tunable set up function for A
     double opt_time = mytimer();
-    OptimizeProblem(A, data, b, x, xexact);
+    OptimizeProblem(A, data, b, x, xexact, gopts);
 #ifdef HPGMP_VERBOSE
     MPI_Barrier(comm);
     if (rank == 0) {
@@ -120,7 +120,7 @@ void SetupProblem(const char* title, int argc, char** argv, comm_type comm, Devi
 #endif
 
     // Call user-tunable set up function for A2
-    OptimizeProblem(A2, data, b, x, xexact);
+    OptimizeProblem(A2, data, b, x, xexact, gopts);
     opt_time = mytimer() - opt_time; // Capture total time of setup
 #ifdef HPGMP_VERBOSE
     MPI_Barrier(comm);
@@ -156,7 +156,7 @@ template void SetupProblem< SparseMatrix<double>, SparseMatrix<double>,
                             Vector<double>>(
     const char*, int, char**, comm_type, DeviceCtx*, int, bool, Geometry*, SparseMatrix<double>&,
     GMRESData<double, double, double>&, SparseMatrix<double>&, GMRESData<double, double, double>&,
-    Vector<double>&, Vector<double>&, TestGMRESData&);
+    Vector<double>&, Vector<double>&, TestGMRESData&, const HPGMP_gen_opts& gopts);
 
 template void SetupProblem< SparseMatrix<float>, SparseMatrix<float>,
                             GMRESData<float, float, float>,
@@ -164,7 +164,7 @@ template void SetupProblem< SparseMatrix<float>, SparseMatrix<float>,
                             Vector<float>>(
     const char*, int, char**, comm_type, DeviceCtx*, int, bool, Geometry*, SparseMatrix<float>&,
     GMRESData<float, float, float>&, SparseMatrix<float>&, GMRESData<float, float, float>&,
-    Vector<float>&, Vector<float>&, TestGMRESData&);
+    Vector<float>&, Vector<float>&, TestGMRESData&, const HPGMP_gen_opts& gopts);
 
 // mixed
 template void SetupProblem< SparseMatrix<double>,
@@ -174,7 +174,7 @@ template void SetupProblem< SparseMatrix<double>,
                             Vector<double>>(
     const char*, int, char**, comm_type, DeviceCtx*, int, bool, Geometry*, SparseMatrix<double>&,
     GMRESData<double, double, double>&, SparseMatrix<float>&, GMRESData<float, float, float>&,
-    Vector<double>&, Vector<double>&, TestGMRESData&);
+    Vector<double>&, Vector<double>&, TestGMRESData&, const HPGMP_gen_opts& gopts);
 
 #ifdef HPGMP_WITH_GINKGO_AMP
 template void SetupProblem< SparseMatrix<double, double>,
@@ -184,5 +184,5 @@ template void SetupProblem< SparseMatrix<double, double>,
                             Vector<double>>(
     const char*, int, char**, comm_type, DeviceCtx*, int, bool, Geometry*, SparseMatrix<double, double>&,
     GMRESData<double, double, double>&, SparseMatrix<double, float>&, GMRESData<double, float, float>&,
-    Vector<double>&, Vector<double>&, TestGMRESData&);
+    Vector<double>&, Vector<double>&, TestGMRESData&, const HPGMP_gen_opts& gopts);
 #endif

--- a/src/SetupProblem.cpp
+++ b/src/SetupProblem.cpp
@@ -180,9 +180,9 @@ template void SetupProblem< SparseMatrix<double>,
 template void SetupProblem< SparseMatrix<double, double>,
                             SparseMatrix<double, float>,
                             GMRESData<double, double, double>,
-                            GMRESData<double, float, double>,
+                            GMRESData<double, float, float>,
                             Vector<double>>(
     const char*, int, char**, comm_type, DeviceCtx*, int, bool, Geometry*, SparseMatrix<double, double>&,
-    GMRESData<double, double, double>&, SparseMatrix<double, float>&, GMRESData<double, float, double>&,
+    GMRESData<double, double, double>&, SparseMatrix<double, float>&, GMRESData<double, float, float>&,
     Vector<double>&, Vector<double>&, TestGMRESData&);
 #endif

--- a/src/SetupProblem.cpp
+++ b/src/SetupProblem.cpp
@@ -52,6 +52,8 @@ void SetupProblem(const char* title, int argc, char** argv, comm_type comm, Devi
                   GMRESData_type& data, SparseMatrix_type2& A2, GMRESData_type2& data2,
                   Vector_type& b, Vector_type& x, TestGMRESData& test_data)
 {
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     HPGMP_Params params;
     HPGMP_Init_Params(title, &argc, &argv, params, comm);
     const int size        = params.comm_size; // Number of MPI processes
@@ -138,6 +140,8 @@ void SetupProblem(const char* title, int argc, char** argv, comm_type comm, Devi
         HPGMP_fout << " Setup    Time     " << setup_time << " seconds." << endl;
         HPGMP_fout << " Optimize Time     " << opt_time << " seconds." << endl;
     }
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 }
 
 

--- a/src/SetupProblem.hpp
+++ b/src/SetupProblem.hpp
@@ -30,6 +30,6 @@
 template<class SparseMatrix_type, class SparseMatrix_type2, class GMRESData_type, class GMRESData_type2, class Vector_type>
 void SetupProblem(const char* title, int argc, char** argv, comm_type comm, DeviceCtx* dctx, int numberOfMgLevels, bool verbose, Geometry* geom,
                   SparseMatrix_type& A, GMRESData_type& data, SparseMatrix_type2& A2, GMRESData_type2& data2,
-                  Vector_type& b, Vector_type& x, TestGMRESData& test_data);
+                  Vector_type& b, Vector_type& x, TestGMRESData& test_data, const HPGMP_gen_opts& gopts);
 
 #endif

--- a/src/SparseMatrix.hpp
+++ b/src/SparseMatrix.hpp
@@ -85,7 +85,7 @@ public:
        used inside optimized ComputeSPMV().
      */
     mutable SparseMatrix<local_scalar_t, halo_scalar_t>* Ac = nullptr; // Coarse grid matrix
-    mutable MGData<local_scalar_t>* mgData                  = nullptr; // Pointer to the coarse level data for this fine matrix
+    mutable MGData<halo_scalar_t>* mgData                   = nullptr; // Pointer to the coarse level data for this fine matrix
     OptimizationData* optimizationData                      = nullptr; // pointer that can be used to store implementation-specific data
 
     // communicator

--- a/src/TestGMRES.cpp
+++ b/src/TestGMRES.cpp
@@ -271,9 +271,9 @@ template int TestGMRES< SparseMatrix<double>,
 template int TestGMRES< SparseMatrix<double>,
                         SparseMatrix<double, float>,
                         GMRESData<double, double, double>,
-                        GMRESData<double, float, double>,
+                        GMRESData<double, float, float>,
                         Vector<double>>(
     SparseMatrix<double>&, SparseMatrix<double, float>&,
-    GMRESData<double, double, double>&, GMRESData<double, float, double>&,
+    GMRESData<double, double, double>&, GMRESData<double, float, float>&,
     Vector<double>&, Vector<double>&, bool, bool, TestGMRESData&);
 #endif

--- a/src/ValidGMRES.cpp
+++ b/src/ValidGMRES.cpp
@@ -247,10 +247,5 @@ template int ValidGMRES<float, float, float >(
     int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&);
 
 // mixed version
-#ifdef HPGMP_WITH_GINKGO_AMP
-template int ValidGMRES<double, float, double >(
-    int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&);
-#else
 template int ValidGMRES<double, float, float >(
     int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&);
-#endif

--- a/src/ValidGMRES.cpp
+++ b/src/ValidGMRES.cpp
@@ -54,7 +54,7 @@
 template<typename scalar_type, typename scalar_type2, class project_type>
 int ValidGMRES(const int argc, char** argv, const validation_t validation_type, comm_type comm,
                DeviceCtx* const dctx, const int numberOfMgLevels, const bool verbose,
-               TestGMRESData& test_data)
+               TestGMRESData& test_data, const HPGMP_gen_opts& gopts)
 {
 
     HPGMP_RANGE_PUSH(__FUNCTION__);
@@ -86,7 +86,7 @@ int ValidGMRES(const int argc, char** argv, const validation_t validation_type, 
 
     Vector_type b, x;
     SetupProblem("valid_", argc, argv, comm, dctx, numberOfMgLevels, verbose, geom, A, data,
-                 A_lo, data_lo, b, x, test_data);
+                 A_lo, data_lo, b, x, test_data, gopts);
 
     //////////////////////////////////////////////////////////
     // Solver Parameters
@@ -241,11 +241,11 @@ int ValidGMRES(const int argc, char** argv, const validation_t validation_type, 
 
 // uniform version
 template int ValidGMRES<double, double, double >(
-    int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&);
+    int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&, const HPGMP_gen_opts& gopts);
 
 template int ValidGMRES<float, float, float >(
-    int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&);
+    int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&, const HPGMP_gen_opts& gopts);
 
 // mixed version
 template int ValidGMRES<double, float, float >(
-    int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&);
+    int, char**, validation_t, comm_type, DeviceCtx*, int, bool, TestGMRESData&, const HPGMP_gen_opts& gopts);

--- a/src/ValidGMRES.cpp
+++ b/src/ValidGMRES.cpp
@@ -56,6 +56,9 @@ int ValidGMRES(const int argc, char** argv, const validation_t validation_type, 
                DeviceCtx* const dctx, const int numberOfMgLevels, const bool verbose,
                TestGMRESData& test_data)
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     typedef Vector<scalar_type> Vector_type;
     typedef SparseMatrix<scalar_type> SparseMatrix_type;
     typedef GMRESData<scalar_type, scalar_type, scalar_type> GMRESData_type;
@@ -229,6 +232,9 @@ int ValidGMRES(const int argc, char** argv, const validation_t validation_type, 
     }
 
     delete geom;
+
+    HPGMP_RANGE_POP(__FUNCTION__);
+
     return fail;
 }
 

--- a/src/ValidGMRES.hpp
+++ b/src/ValidGMRES.hpp
@@ -31,6 +31,6 @@
 
 template<typename scalar_type, typename scalar_type2, typename project_type = scalar_type2>
 int ValidGMRES(int argc, char** argv, validation_t v_type, comm_type comm, DeviceCtx* dctx,
-               int numberOfMgLevels, bool verbose, TestGMRESData& testcg_data);
+               int numberOfMgLevels, bool verbose, TestGMRESData& testcg_data, const HPGMP_gen_opts& gopts);
 
 #endif // BENCHGMRES_HPP

--- a/src/ell_matrix.dev.cpp
+++ b/src/ell_matrix.dev.cpp
@@ -159,13 +159,13 @@ __launch_bounds__(BLOCKSIZEX* BLOCKSIZEY)
 #endif
 }
 
-template<unsigned int BLOCKSIZEX, unsigned int BLOCKSIZEY, typename mat_scalar_type>
+template<unsigned int BLOCKSIZEX, unsigned int BLOCKSIZEY, typename local_scalar_t>
 __launch_bounds__(BLOCKSIZEX* BLOCKSIZEY)
     __global__ void kernel_to_ell_val(const local_int_t m,
                                       const local_int_t nnz_per_row,
                                       const int ld_v,
-                                      const mat_scalar_type* __restrict__ matrixValues,
-                                      mat_scalar_type* __restrict__ ell_val)
+                                      const local_scalar_t* __restrict__ matrixValues,
+                                      local_scalar_t* __restrict__ ell_val)
 {
     const local_int_t row = blockIdx.x * BLOCKSIZEY + threadIdx.y;
 
@@ -386,13 +386,13 @@ void ELLMatrix<local_scalar_t, halo_scalar_t>::permute_rows(const local_int_t* c
     dctx_->device_free(tmp_vals);
 }
 
-template<unsigned int BLOCKSIZE, typename mat_scalar_type, typename diag_scalar>
+template<unsigned int BLOCKSIZE, typename local_scalar_t, typename diag_scalar>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_extract_diag_index(const local_int_t m,
                                               const local_int_t ell_width,
                                               const int ldi, const int ldv,
                                               const local_int_t* __restrict__ ell_col_ind,
-                                              const mat_scalar_type* __restrict__ ell_val,
+                                              const local_scalar_t* __restrict__ ell_val,
                                               local_int_t* __restrict__ diag_idx,
                                               diag_scalar* __restrict__ inv_diag)
 {
@@ -430,10 +430,10 @@ template class ELLMatrix<double, double>;
 template class ELLMatrix<float, float>;
 template class ELLMatrix<double, float>;
 
-template<typename mat_scalar_type, typename vec_scalar_t>
+template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __global__ void simple_ell_spmv(const local_int_t nrows, const int ldv, const int ldi,
                                 const local_int_t width,
-                                const local_int_t* const col_idxs, const mat_scalar_type* const mvalues,
+                                const local_int_t* const col_idxs, const local_scalar_t* const mvalues,
                                 const vec_scalar_t* const xvals, vec_scalar_t* const __restrict__ yvals)
 {
     const local_int_t row_idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -457,10 +457,10 @@ __global__ void simple_ell_spmv(const local_int_t nrows, const int ldv, const in
     __stcg(yvals + row_idx, partial);
 }
 
-template<typename mat_scalar_type, typename vec_scalar_t>
+template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __global__ void simple_ell_spmv_halo(const local_int_t nrows, const int ldv, const int ldi,
                                      const local_int_t width, const local_int_t* const halo_row_ind,
-                                     const local_int_t* const col_idxs, const mat_scalar_type* const mvalues,
+                                     const local_int_t* const col_idxs, const halo_scalar_t* const halo_values,
                                      const local_int_t* const perm,
                                      const vec_scalar_t* const xvals, vec_scalar_t* const __restrict__ yvals)
 {
@@ -474,20 +474,21 @@ __global__ void simple_ell_spmv_halo(const local_int_t nrows, const int ldv, con
         if (col < 0) {
             continue;
         }
-        partial += static_cast<vec_scalar_t>(mvalues[row_idx + j * ldv]) * static_cast<vec_scalar_t>(xvals[col]);
+        partial += static_cast<vec_scalar_t>(halo_values[row_idx + j * ldv]) * static_cast<vec_scalar_t>(xvals[col]);
     }
     yvals[perm[halo_row_ind[row_idx]]] += partial;
 }
 
-template<typename mat_scalar_type, typename vec_scalar_t>
-void ell_interior_spmv(const ELLMatrix<mat_scalar_type, mat_scalar_type>* mat, const Vector<vec_scalar_t>* x, Vector<vec_scalar_t>* y)
+template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
+void ell_interior_spmv(const ELLMatrix<local_scalar_t, halo_scalar_t>* mat, const Vector<vec_scalar_t>* x, Vector<vec_scalar_t>* y)
 {
     constexpr int block_size = 1024;
     int nblocks              = (mat->get_local_num_rows() - 1) / block_size + 1;
     auto stream              = mat->get_device_context()->get_compute_stream();
-    simple_ell_spmv<<<nblocks, block_size, 0, stream>>>(mat->get_local_num_rows(),
-                                                        mat->get_ld_values(), mat->get_ld_indices(), mat->get_ell_width(),
-                                                        mat->get_col_idxs(), mat->get_values(), x->d_values(), y->d_values());
+    simple_ell_spmv<local_scalar_t, halo_scalar_t, vec_scalar_t>
+        <<<nblocks, block_size, 0, stream>>>(mat->get_local_num_rows(),
+                                             mat->get_ld_values(), mat->get_ld_indices(), mat->get_ell_width(),
+                                             mat->get_col_idxs(), mat->get_values(), x->d_values(), y->d_values());
 }
 
 template void ell_interior_spmv(const ELLMatrix<double, double>* mat, const Vector<double>* x, Vector<double>* y);
@@ -502,10 +503,11 @@ void ell_halo_spmv(const ELLMatrix<local_scalar_t, halo_scalar_t>* mat,
     const int nblocks        = (mat->get_num_halo_rows() - 1) / block_size + 1;
     // We use the compute stream since the halo spmv *adds* to the output vector y after the interior spmv.
     auto stream = mat->get_device_context()->get_compute_stream();
-    simple_ell_spmv_halo<<<nblocks, block_size, 0, stream>>>(mat->get_num_halo_rows(),
-                                                             mat->get_halo_ld_values(), mat->get_halo_ld_indices(), mat->get_ell_width(),
-                                                             mat->get_halo_row_indices(), mat->get_halo_col_idxs(), mat->get_halo_values(),
-                                                             mat->get_reordering_permutation(), x->d_values(), y->d_values());
+    simple_ell_spmv_halo<local_scalar_t, halo_scalar_t>
+        <<<nblocks, block_size, 0, stream>>>(mat->get_num_halo_rows(),
+                                             mat->get_halo_ld_values(), mat->get_halo_ld_indices(), mat->get_ell_width(),
+                                             mat->get_halo_row_indices(), mat->get_halo_col_idxs(), mat->get_halo_values(),
+                                             mat->get_reordering_permutation(), x->d_values(), y->d_values());
 }
 
 template void ell_halo_spmv(const ELLMatrix<double, double>* mat, const Vector<double>* x, Vector<double>* y);
@@ -514,8 +516,8 @@ template void ell_halo_spmv(const ELLMatrix<float, float>* mat, const Vector<dou
 template void ell_halo_spmv(const ELLMatrix<double, float>* mat, const Vector<double>* x, Vector<double>* y);
 template void ell_halo_spmv(const ELLMatrix<double, float>* mat, const Vector<float>* x, Vector<float>* y);
 
-template<typename mat_scalar_type, typename vec_scalar_t>
-void ell_spmv(const ELLMatrix<mat_scalar_type, mat_scalar_type>* mat, const Vector<vec_scalar_t>* x, Vector<vec_scalar_t>* y)
+template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
+void ell_spmv(const ELLMatrix<local_scalar_t, halo_scalar_t>* mat, const Vector<vec_scalar_t>* x, Vector<vec_scalar_t>* y)
 {
     auto dctx = x->get_device_context();
 
@@ -541,9 +543,11 @@ int ComputeSPMV_ell(const SparseMatrix_type& A, Vector_type& x, Vector_type& y)
 
     HPGMP_RANGE_PUSH(__FUNCTION__);
 
-    using scalar_type = typename SparseMatrix_type::scalar_type;
-    auto elldata      = static_cast<const EllOptData<scalar_type, scalar_type>*>(A.optimizationData);
-    ell_spmv(elldata->mat.get(), &x, &y);
+    using local_scalar_t = typename SparseMatrix_type::local_scalar_type;
+    using halo_scalar_t  = typename SparseMatrix_type::halo_scalar_type;
+    using vev_scalar_t   = typename Vector_type::scalar_type;
+    auto elldata         = static_cast<const EllOptData<local_scalar_t, halo_scalar_t>*>(A.optimizationData);
+    ell_spmv<local_scalar_t, halo_scalar_t, vev_scalar_t>(elldata->mat.get(), &x, &y);
 
     HPGMP_RANGE_POP(__FUNCTION__);
 

--- a/src/ell_multicolor_gs.dev.cpp
+++ b/src/ell_multicolor_gs.dev.cpp
@@ -47,70 +47,73 @@
 
 #include "kernel_helpers.hpp.inc"
 
-#define LAUNCH_SYMGS_SWEEP(blocksize, width)                                  \
-    {                                                                         \
-        dim3 blocks((A->get_independent_set_sizes()[i] - 1) / blocksize + 1); \
-        dim3 threads(blocksize);                                              \
-                                                                              \
-        kernel_symgs_sweep<blocksize, width><<<blocks,                        \
-                                               threads,                       \
-                                               0,                             \
-                                               stream_interior>>>(            \
-            A->get_local_num_rows(),                                          \
-            A->get_local_num_cols(),                                          \
-            A->get_independent_set_sizes()[i],                                \
-            A->get_independent_set_offsets()[i],                              \
-            A->get_ld_indices(), A->get_ld_values(),                          \
-            A->get_col_idxs(),                                                \
-            A->get_values(),                                                  \
-            A->get_inverse_diagonal(),                                        \
-            r->d_values(),                                                    \
-            x->d_values());                                                   \
+#define LAUNCH_SYMGS_SWEEP(blocksize, width)                                              \
+    {                                                                                     \
+        dim3 blocks((A->get_independent_set_sizes()[i] - 1) / blocksize + 1);             \
+        dim3 threads(blocksize);                                                          \
+                                                                                          \
+        kernel_symgs_sweep<blocksize, width, local_scalar_t, halo_scalar_t, vec_scalar_t> \
+            <<<blocks,                                                                    \
+               threads,                                                                   \
+               0,                                                                         \
+               stream_interior>>>(                                                        \
+                A->get_local_num_rows(),                                                  \
+                A->get_local_num_cols(),                                                  \
+                A->get_independent_set_sizes()[i],                                        \
+                A->get_independent_set_offsets()[i],                                      \
+                A->get_ld_indices(), A->get_ld_values(),                                  \
+                A->get_col_idxs(),                                                        \
+                A->get_values(),                                                          \
+                A->get_inverse_diagonal(),                                                \
+                r->d_values(),                                                            \
+                x->d_values());                                                           \
     }
 
-#define LAUNCH_SYMGS_INTERIOR(blocksize, width)                               \
-    {                                                                         \
-        dim3 blocks((A->get_independent_set_sizes()[0] - 1) / blocksize + 1); \
-        dim3 threads(blocksize);                                              \
-                                                                              \
-        kernel_symgs_interior<blocksize, width><<<blocks,                     \
-                                                  threads,                    \
-                                                  0,                          \
-                                                  stream_interior>>>(         \
-            A->get_local_num_rows(),                                          \
-            A->get_independent_set_sizes()[0],                                \
-            A->get_ld_indices(), A->get_ld_values(),                          \
-            A->get_col_idxs(),                                                \
-            A->get_values(),                                                  \
-            A->get_inverse_diagonal(),                                        \
-            r->d_values(),                                                    \
-            x->d_values());                                                   \
+#define LAUNCH_SYMGS_INTERIOR(blocksize, width)                                              \
+    {                                                                                        \
+        dim3 blocks((A->get_independent_set_sizes()[0] - 1) / blocksize + 1);                \
+        dim3 threads(blocksize);                                                             \
+                                                                                             \
+        kernel_symgs_interior<blocksize, width, local_scalar_t, halo_scalar_t, vec_scalar_t> \
+            <<<blocks,                                                                       \
+               threads,                                                                      \
+               0,                                                                            \
+               stream_interior>>>(                                                           \
+                A->get_local_num_rows(),                                                     \
+                A->get_independent_set_sizes()[0],                                           \
+                A->get_ld_indices(), A->get_ld_values(),                                     \
+                A->get_col_idxs(),                                                           \
+                A->get_values(),                                                             \
+                A->get_inverse_diagonal(),                                                   \
+                r->d_values(),                                                               \
+                x->d_values());                                                              \
     }
 
-#define LAUNCH_SYMGS_HALO(blocksize, width)                        \
-    {                                                              \
-        dim3 blocks((A->get_num_halo_rows() - 1) / blocksize + 1); \
-        dim3 threads(blocksize);                                   \
-                                                                   \
-        kernel_symgs_halo<blocksize, width><<<blocks,              \
-                                              threads,             \
-                                              0,                   \
-                                              stream_interior>>>(  \
-            A->get_num_halo_rows(),                                \
-            A->get_local_num_cols(),                               \
-            A->get_independent_set_sizes()[0],                     \
-            A->get_halo_ld_indices(), A->get_halo_ld_values(),     \
-            A->get_halo_row_indices(),                             \
-            A->get_halo_col_idxs(),                                \
-            A->get_halo_values(),                                  \
-            A->get_inverse_diagonal(),                             \
-            A->get_reordering_permutation(),                       \
-            r->d_values(),                                         \
-            x->d_values());                                        \
+#define LAUNCH_SYMGS_HALO(blocksize, width)                                              \
+    {                                                                                    \
+        dim3 blocks((A->get_num_halo_rows() - 1) / blocksize + 1);                       \
+        dim3 threads(blocksize);                                                         \
+                                                                                         \
+        kernel_symgs_halo<blocksize, width, local_scalar_t, halo_scalar_t, vec_scalar_t> \
+            <<<blocks,                                                                   \
+               threads,                                                                  \
+               0,                                                                        \
+               stream_interior>>>(                                                       \
+                A->get_num_halo_rows(),                                                  \
+                A->get_local_num_cols(),                                                 \
+                A->get_independent_set_sizes()[0],                                       \
+                A->get_halo_ld_indices(), A->get_halo_ld_values(),                       \
+                A->get_halo_row_indices(),                                               \
+                A->get_halo_col_idxs(),                                                  \
+                A->get_halo_values(),                                                    \
+                A->get_inverse_diagonal(),                                               \
+                A->get_reordering_permutation(),                                         \
+                r->d_values(),                                                           \
+                x->d_values());                                                          \
     }
 
 template<unsigned int BLOCKSIZE, unsigned int WIDTH,
-         typename mat_scalar_type, typename diag_scalar, typename vec_scalar_t>
+         typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_symgs_sweep(const local_int_t m,
                                        const local_int_t n,
@@ -118,8 +121,8 @@ __launch_bounds__(BLOCKSIZE)
                                        const local_int_t offset,
                                        const int ldi, const int ldv,
                                        const local_int_t* ell_col_ind,
-                                       const mat_scalar_type* ell_val,
-                                       const diag_scalar* inv_diag,
+                                       const local_scalar_t* ell_val,
+                                       const local_scalar_t* inv_diag,
                                        const vec_scalar_t* x,
                                        vec_scalar_t* y)
 {
@@ -147,14 +150,14 @@ __launch_bounds__(BLOCKSIZE)
 }
 
 template<unsigned int BLOCKSIZE, unsigned int WIDTH,
-         typename mat_scalar_type, typename diag_scalar, typename vec_scalar_t>
+         typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_symgs_interior(const local_int_t m,
                                           const local_int_t block_nrow,
                                           const int ldi, const int ldv,
                                           const local_int_t* ell_col_ind,
-                                          const mat_scalar_type* ell_val,
-                                          const diag_scalar* inv_diag,
+                                          const local_scalar_t* ell_val,
+                                          const local_scalar_t* inv_diag,
                                           const vec_scalar_t* x,
                                           vec_scalar_t* y)
 {
@@ -180,7 +183,7 @@ __launch_bounds__(BLOCKSIZE)
 }
 
 template<unsigned int BLOCKSIZE, unsigned int WIDTH,
-         typename mat_scalar_type, typename diag_scalar, typename vec_scalar_t>
+         typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_symgs_halo(const local_int_t m,
                                       const local_int_t n,
@@ -188,8 +191,8 @@ __launch_bounds__(BLOCKSIZE)
                                       const int ldi, const int ldv,
                                       const local_int_t* halo_row_ind,
                                       const local_int_t* halo_col_ind,
-                                      const mat_scalar_type* halo_val,
-                                      const diag_scalar* inv_diag,
+                                      const halo_scalar_t* halo_val,
+                                      const local_scalar_t* inv_diag,
                                       const local_int_t* perm,
                                       const vec_scalar_t* x,
                                       vec_scalar_t* y)
@@ -234,14 +237,14 @@ __launch_bounds__(BLOCKSIZE)
     out[gid] = x[gid] * y[gid];
 }
 
-template<unsigned int BLOCKSIZE, typename mat_scalar_type, typename vec_scalar_t>
+template<unsigned int BLOCKSIZE, typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_forward_sweep_0(const local_int_t m,
                                            const local_int_t block_nrow,
                                            const local_int_t offset,
                                            const int ldi, const int ldv,
                                            const local_int_t* ell_col_ind,
-                                           const mat_scalar_type* ell_val,
+                                           const local_scalar_t* ell_val,
                                            const local_int_t* diag_idx,
                                            const vec_scalar_t* x,
                                            vec_scalar_t* y)
@@ -270,7 +273,7 @@ __launch_bounds__(BLOCKSIZE)
     __stcg(y + row, sum);
 }
 
-template<unsigned int BLOCKSIZE, typename mat_scalar_type, typename vec_scalar_t>
+template<unsigned int BLOCKSIZE, typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_backward_sweep_0(const local_int_t m,
                                             const local_int_t block_nrow,
@@ -278,7 +281,7 @@ __launch_bounds__(BLOCKSIZE)
                                             const local_int_t ell_width,
                                             const int ldi, const int ldv,
                                             const local_int_t* ell_col_ind,
-                                            const mat_scalar_type* ell_val,
+                                            const local_scalar_t* ell_val,
                                             const local_int_t* diag_idx,
                                             vec_scalar_t* x)
 {
@@ -290,7 +293,7 @@ __launch_bounds__(BLOCKSIZE)
     const local_int_t row   = gid + offset;
     const local_int_t idiag = __ldcg(diag_idx + row);
 
-    const mat_scalar_type diag_val = __ldcg(ell_val + row + idiag * ldv);
+    const local_scalar_t diag_val = __ldcg(ell_val + row + idiag * ldv);
 
     // Scale result with diagonal entry
     vec_scalar_t sum = x[row] * static_cast<vec_scalar_t>(diag_val);
@@ -309,8 +312,8 @@ __launch_bounds__(BLOCKSIZE)
     __stcg(x + row, sum);
 }
 
-template<typename mat_scalar_type, typename vec_scalar_t>
-int ell_multicolor_gs(const bool symmetric, const ELLMatrix<mat_scalar_type, mat_scalar_type>* const A,
+template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
+int ell_multicolor_gs(const bool symmetric, const ELLMatrix<local_scalar_t, halo_scalar_t>* const A,
                       const Vector<vec_scalar_t>* const r, Vector<vec_scalar_t>* const x)
 {
     assert(x->local_length() == A->get_local_num_cols());
@@ -361,8 +364,8 @@ int ell_multicolor_gs(const bool symmetric, const ELLMatrix<mat_scalar_type, mat
     return 0;
 }
 
-template<typename mat_scalar_type, typename vec_scalar_t>
-int ell_multicolor_gs_zero_initial(const bool symmetric, const ELLMatrix<mat_scalar_type, mat_scalar_type>* const A,
+template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
+int ell_multicolor_gs_zero_initial(const bool symmetric, const ELLMatrix<local_scalar_t, halo_scalar_t>* const A,
                                    const Vector<vec_scalar_t>* const r, Vector<vec_scalar_t>* const x)
 {
     assert(x->local_length() == A->get_local_num_cols());
@@ -370,24 +373,20 @@ int ell_multicolor_gs_zero_initial(const bool symmetric, const ELLMatrix<mat_sca
     auto stream_interior = dctx->get_compute_stream();
 
     // Solve L
-    kernel_pointwise_mult<256><<<(A->get_independent_set_sizes()[0] - 1) / 256 + 1,
-                                 256,
-                                 0,
-                                 stream_interior>>>(
-        A->get_independent_set_sizes()[0], r->d_values(), A->get_inverse_diagonal(),
-        x->d_values());
+    kernel_pointwise_mult<256>
+        <<<(A->get_independent_set_sizes()[0] - 1) / 256 + 1, 256, 0, stream_interior>>>(
+            A->get_independent_set_sizes()[0], r->d_values(), A->get_inverse_diagonal(),
+            x->d_values());
 
     for (local_int_t i = 1; i < A->get_num_independent_sets(); ++i)
     {
-        kernel_forward_sweep_0<1024><<<(A->get_independent_set_sizes()[i] - 1) / 1024 + 1,
-                                       1024,
-                                       0,
-                                       stream_interior>>>(
-            A->get_local_num_rows(),
-            A->get_independent_set_sizes()[i], A->get_independent_set_offsets()[i],
-            A->get_ld_indices(), A->get_ld_values(),
-            A->get_col_idxs(), A->get_values(),
-            A->get_diagonal_indices(), r->d_values(), x->d_values());
+        kernel_forward_sweep_0<1024, local_scalar_t, halo_scalar_t, vec_scalar_t>
+            <<<(A->get_independent_set_sizes()[i] - 1) / 1024 + 1, 1024, 0, stream_interior>>>(
+                A->get_local_num_rows(),
+                A->get_independent_set_sizes()[i], A->get_independent_set_offsets()[i],
+                A->get_ld_indices(), A->get_ld_values(),
+                A->get_col_idxs(), A->get_values(),
+                A->get_diagonal_indices(), r->d_values(), x->d_values());
     }
 
     if (symmetric) {

--- a/src/ell_multicolor_gs.hpp
+++ b/src/ell_multicolor_gs.hpp
@@ -28,12 +28,12 @@
  *
  * @return returns 0 upon success and non-zero otherwise
  */
-template<typename mat_scalar_type, typename vec_scalar_t>
-int ell_multicolor_gs(bool symmetric, const ELLMatrix<mat_scalar_type, mat_scalar_type>* A, const Vector<vec_scalar_t>* r,
+template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
+int ell_multicolor_gs(bool symmetric, const ELLMatrix<local_scalar_t, halo_scalar_t>* A, const Vector<vec_scalar_t>* r,
                       Vector<vec_scalar_t>* x);
 
-template<typename mat_scalar_type, typename vec_scalar_t>
-int ell_multicolor_gs_zero_initial(bool symmetric, const ELLMatrix<mat_scalar_type, mat_scalar_type>* A,
+template<typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
+int ell_multicolor_gs_zero_initial(bool symmetric, const ELLMatrix<local_scalar_t, halo_scalar_t>* A,
                                    const Vector<vec_scalar_t>* r, Vector<vec_scalar_t>* x);
 
 #endif

--- a/src/estimate_run_time.cpp
+++ b/src/estimate_run_time.cpp
@@ -91,7 +91,7 @@ template double estimate_run_time(comm_type comm,
 #ifdef HPGMP_WITH_GINKGO_AMP
 template double estimate_run_time(comm_type comm,
                                   const SparseMatrix<double, double>& A, const SparseMatrix<double, float>& A_lo,
-                                  GMRESData<double, double, double>& data, GMRESData<double, float, double>& data_lo,
+                                  GMRESData<double, double, double>& data, GMRESData<double, float, float>& data_lo,
                                   const Vector<double>& b, Vector<double>& x, int max_iters,
                                   int restart_length, bool verbose);
 #else

--- a/src/estimate_run_time.cpp
+++ b/src/estimate_run_time.cpp
@@ -5,21 +5,17 @@
 #include "mytimer.hpp"
 #include "GMRES_IR.hpp"
 
-#ifdef HPGMP_WITH_GINKGO_AMP // TODO: Improve this implementation
 template<typename scalar_type, typename scalar_type2, class GMRESData_type, class GMRESData_type2>
 double estimate_run_time(comm_type comm,
-                         const SparseMatrix<scalar_type, scalar_type>& A, const SparseMatrix<scalar_type, scalar_type2>& A_lo,
-                         GMRESData_type& data, GMRESData_type2& data_lo,
-                         const Vector<scalar_type>& b, Vector<scalar_type>& x, const int max_iters,
-                         const int restart_length, const bool verbose)
+                         const SparseMatrix<scalar_type, scalar_type>& A, 
+#ifdef HPGMP_WITH_GINKGO_AMP
+                         const SparseMatrix<scalar_type, scalar_type2>& A_lo,
 #else
-template<typename scalar_type, typename scalar_type2, class GMRESData_type, class GMRESData_type2>
-double estimate_run_time(comm_type comm,
-                         const SparseMatrix<scalar_type, scalar_type>& A, const SparseMatrix<scalar_type2, scalar_type2>& A_lo,
+                         const SparseMatrix<scalar_type2, scalar_type2>& A_lo,
+#endif
                          GMRESData_type& data, GMRESData_type2& data_lo,
                          const Vector<scalar_type>& b, Vector<scalar_type>& x, const int max_iters,
                          const int restart_length, const bool verbose)
-#endif
 {
     HPGMP_RANGE_PUSH(__FUNCTION__);
 

--- a/src/estimate_run_time.cpp
+++ b/src/estimate_run_time.cpp
@@ -7,7 +7,7 @@
 
 template<typename scalar_type, typename scalar_type2, class GMRESData_type, class GMRESData_type2>
 double estimate_run_time(comm_type comm,
-                         const SparseMatrix<scalar_type, scalar_type>& A, 
+                         const SparseMatrix<scalar_type, scalar_type>& A,
 #ifdef HPGMP_WITH_GINKGO_AMP
                          const SparseMatrix<scalar_type, scalar_type2>& A_lo,
 #else

--- a/src/hpgmp.hpp
+++ b/src/hpgmp.hpp
@@ -119,6 +119,7 @@ struct HPGMP_gen_opts
 {
     validation_t validation_type;
     run_t run_type;
+    double amp_tol;
 };
 
 /*!

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -57,6 +57,22 @@ startswith(const char* s, const char* prefix)
     return 1;
 }
 
+// Reading configuration file for backward compatibility
+// @todo Remove this eventually, and only support command line
+#ifdef HPGMP_WITH_GINKGO_AMP
+int read_amp_config(double& tol)
+{
+    std::ifstream amp_config_file("amp_config.txt");
+
+    if (amp_config_file.is_open()) {
+        amp_config_file >> tol;
+        amp_config_file.close();
+    }
+
+    return 0;
+}
+#endif
+
 HPGMP_gen_opts
 HPGMP_Init(int* argc_p, char*** argv_p)
 {
@@ -64,12 +80,13 @@ HPGMP_Init(int* argc_p, char*** argv_p)
     const int argc = *argc_p;
     char** argv    = *argv_p;
     // Options to be read
-    constexpr int nparams                          = 2;
-    const std::array<std::string, nparams> cparams = {"--validation_type", "--run_type"};
+    constexpr int nparams                          = 3;
+    const std::array<std::string, nparams> cparams = {"--validation_type", "--run_type", "--amp_tol"};
     std::array<std::string, nparams> values;
     // Default values
     values[0] = "standard";
     values[1] = "benchmark";
+    values[2] = "1e-8";
 
     // Read cmd line args
     for (int i = 1; i <= argc && argv[i]; ++i) {
@@ -87,6 +104,8 @@ HPGMP_Init(int* argc_p, char*** argv_p)
             throw std::runtime_error("Could not read cmd line option prefix!");
         }
     }
+
+    // Set validation_type in opts
     if (values[0] == "standard") {
         opts.validation_type = validation_t::standard;
     } else if (values[0] == "fullscale") {
@@ -94,6 +113,8 @@ HPGMP_Init(int* argc_p, char*** argv_p)
     } else {
         throw std::runtime_error("Invalid value for validation_type!");
     }
+
+    // Set run_type in opts
     if (values[1] == "benchmark") {
         opts.run_type = run_t::benchmark;
     } else if (values[1] == "benchmark_no_ref") {
@@ -105,6 +126,17 @@ HPGMP_Init(int* argc_p, char*** argv_p)
     } else {
         throw std::runtime_error("Invalid value for run_type!");
     }
+
+    // Set amp_tol in opts
+    opts.amp_tol = std::stod(values[2]);
+
+#ifdef HPGMP_WITH_GINKGO_AMP
+    // Reading configuration file for backward compatibility. 
+    // This overrides the command line argument if the file is provided.
+    // @todo Remove this eventually, and only support command line
+    read_amp_config(opts.amp_tol);
+#endif
+
     return opts;
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -131,7 +131,7 @@ HPGMP_Init(int* argc_p, char*** argv_p)
     opts.amp_tol = std::stod(values[2]);
 
 #ifdef HPGMP_WITH_GINKGO_AMP
-    // Reading configuration file for backward compatibility. 
+    // Reading configuration file for backward compatibility.
     // This overrides the command line argument if the file is provided.
     // @todo Remove this eventually, and only support command line
     read_amp_config(opts.amp_tol);

--- a/src/main_hpgmp.cpp
+++ b/src/main_hpgmp.cpp
@@ -222,7 +222,7 @@ int main(int argc, char* argv[])
         TICK();
         global_failure = ValidGMRES<scalar_type, scalar_type2, project_type>(
             argc, argv, gopts.validation_type, validation_comm, ctx.get(),
-            numberOfMgLevels, verbose, test_data);
+            numberOfMgLevels, verbose, test_data, gopts);
         double t_valid{};
         TOCK(t_valid);
         if (myRank == 0) {

--- a/src/main_hpgmp.cpp
+++ b/src/main_hpgmp.cpp
@@ -55,7 +55,7 @@ typedef GMRESData<scalar_type, scalar_type, scalar_type> GMRESData_type;
 
 typedef Vector<scalar_type2> Vector_type2;
 #ifdef HPGMP_WITH_GINKGO_AMP
-using project_type = double;
+using project_type = float;
 typedef SparseMatrix<scalar_type, scalar_type2> SparseMatrix_type2;
 typedef GMRESData<scalar_type, scalar_type2, project_type> GMRESData_type2;
 #else

--- a/src/main_time.cpp
+++ b/src/main_time.cpp
@@ -64,7 +64,7 @@ typedef GMRESData<scalar_type, scalar_type, scalar_type> GMRESData_type;
 
 typedef Vector<scalar_type2> Vector_type2;
 #ifdef HPGMP_WITH_GINKGO_AMP
-using project_type = double;
+using project_type = float;
 typedef SparseMatrix<scalar_type, scalar_type2> SparseMatrix_type2;
 typedef GMRESData<scalar_type, scalar_type2, project_type> GMRESData_type2;
 #else

--- a/src/main_time.cpp
+++ b/src/main_time.cpp
@@ -89,7 +89,7 @@ int main(int argc, char* argv[])
 #ifndef HPGMP_NO_MPI
     MPI_Init(&argc, &argv);
 #endif
-    HPGMP_Init(&argc, &argv);
+    const HPGMP_gen_opts gopts = HPGMP_Init(&argc, &argv);
 #ifndef HPGMP_NO_MPI
     MPI_Comm bench_comm = MPI_COMM_WORLD;
 #else
@@ -170,7 +170,7 @@ int main(int argc, char* argv[])
 
     // Call user-tunable set up function.
     double t7 = mytimer();
-    OptimizeProblem(A, data, b, x, xexact);
+    OptimizeProblem(A, data, b, x, xexact, gopts);
     t7       = mytimer() - t7;
     times[7] = t7;
 
@@ -220,7 +220,7 @@ int main(int argc, char* argv[])
     setup_time = mytimer() - setup_time; // Capture total time of setup
 
     t7 = mytimer();
-    OptimizeProblem(A2, data, b, x, xexact);
+    OptimizeProblem(A2, data, b, x, xexact, gopts);
     t7 = mytimer() - t7;
 
     if (A.geom->rank == 0) {

--- a/src/matrix_base.cpp
+++ b/src/matrix_base.cpp
@@ -23,8 +23,8 @@ DistMatrixBase::DistMatrixBase(const SparseMatrix<local_scalar_t, halo_scalar_t>
       ind_perm_{A.perm},
       ind_sizes_{A.sizes},
       ind_offsets_{A.offsets},
-      sendBuffer_{dctx_->pinned_host_alloc(totalToBeSent_ * sizeof(halo_scalar_t))},
-      d_sendBuffer_{dctx_->device_alloc(totalToBeSent_ * sizeof(halo_scalar_t))}
+      sendBuffer_{dctx_->pinned_host_alloc(totalToBeSent_ * sizeof(local_scalar_t))},
+      d_sendBuffer_{dctx_->device_alloc(totalToBeSent_ * sizeof(local_scalar_t))}
 {
     dctx_->copy_host_to_device_sync(elementsToSend_, A.elementsToSend,
                                     totalToBeSent_ * sizeof(local_int_t));

--- a/src/matrix_base.cpp
+++ b/src/matrix_base.cpp
@@ -23,8 +23,8 @@ DistMatrixBase::DistMatrixBase(const SparseMatrix<local_scalar_t, halo_scalar_t>
       ind_perm_{A.perm},
       ind_sizes_{A.sizes},
       ind_offsets_{A.offsets},
-      sendBuffer_{dctx_->pinned_host_alloc(totalToBeSent_ * sizeof(local_scalar_t))},
-      d_sendBuffer_{dctx_->device_alloc(totalToBeSent_ * sizeof(local_scalar_t))}
+      sendBuffer_{dctx_->pinned_host_alloc(totalToBeSent_ * sizeof(halo_scalar_t))},
+      d_sendBuffer_{dctx_->device_alloc(totalToBeSent_ * sizeof(halo_scalar_t))}
 {
     dctx_->copy_host_to_device_sync(elementsToSend_, A.elementsToSend,
                                     totalToBeSent_ * sizeof(local_int_t));

--- a/src/optimize_problem_ell_rb.cpp
+++ b/src/optimize_problem_ell_rb.cpp
@@ -149,11 +149,17 @@ template int OptimizeProblemELL(SparseMatrix<float>& A, GMRESData<float, float, 
 template int OptimizeProblemELL(SparseMatrix<float>& A, GMRESData<double, double, double>& data,
                                 Vector<double>& b, Vector<double>& x, Vector<double>& xexact);
 
-template int OptimizeProblemELL(SparseMatrix<double, float>& A, GMRESData<double, float, double>& data,
+template int OptimizeProblemELL(SparseMatrix<double, float>& A, GMRESData<double, float, float>& data,
+                                Vector<double>& b, Vector<double>& x, Vector<double>& xexact);
+
+template int OptimizeProblemELL(SparseMatrix<double, float>& A, GMRESData<double, float, float>& data,
                                 Vector<float>& b, Vector<float>& x, Vector<float>& xexact);
 
 template int OptimizeProblemELL(SparseMatrix<double, float>& A, GMRESData<double, double, double>& data,
                                 Vector<double>& b, Vector<double>& x, Vector<double>& xexact);
+
+template int OptimizeProblemELL(SparseMatrix<double, float>& A, GMRESData<double, double, double>& data,
+                                Vector<float>& b, Vector<float>& x, Vector<float>& xexact);
 
 #if 0
 template <typename scalar_t>

--- a/src/optimize_problem_ell_rb.cpp
+++ b/src/optimize_problem_ell_rb.cpp
@@ -59,7 +59,8 @@
 */
 template<typename local_scalar_t, typename halo_scalar_t, class GMRESData_type, typename vec_scalar_t>
 int OptimizeProblemELL(SparseMatrix<local_scalar_t, halo_scalar_t>& A, GMRESData_type& data,
-                       Vector<vec_scalar_t>& b, Vector<vec_scalar_t>& x, Vector<vec_scalar_t>& xexact)
+                       Vector<vec_scalar_t>& b, Vector<vec_scalar_t>& x, Vector<vec_scalar_t>& xexact,
+                       const HPGMP_gen_opts& gopts)
 {
 
     HPGMP_RANGE_PUSH(__FUNCTION__);
@@ -100,7 +101,7 @@ int OptimizeProblemELL(SparseMatrix<local_scalar_t, halo_scalar_t>& A, GMRESData
 #endif
 #ifdef HPGMP_WITH_GINKGO
         auto moptdata       = new GinkgoOptData<local_scalar_t, halo_scalar_t>;
-        auto mat            = std::make_shared<GinkgoMatrix<local_scalar_t, halo_scalar_t>>(*M);
+        auto mat            = std::make_shared<GinkgoMatrix<local_scalar_t, halo_scalar_t>>(*M, gopts);
         moptdata->mat       = mat;
         moptdata->smoother  = std::make_shared<GinkgoSmoother<local_scalar_t, halo_scalar_t>>(mat.get());
         M->optimizationData = moptdata;
@@ -134,32 +135,26 @@ int OptimizeProblemELL(SparseMatrix<local_scalar_t, halo_scalar_t>& A, GMRESData
     return 0;
 }
 
-// Helper function (see OptimizeProblem.hpp for details)
-//double OptimizeProblemMemoryUse(const SparseMatrix & A)
-//{
-//    return 0.0;
-//}
-
 template int OptimizeProblemELL(SparseMatrix<double>& A, GMRESData<double, double, double>& data,
-                                Vector<double>& b, Vector<double>& x, Vector<double>& xexact);
+                                Vector<double>& b, Vector<double>& x, Vector<double>& xexact, const HPGMP_gen_opts&);
 
 template int OptimizeProblemELL(SparseMatrix<float>& A, GMRESData<float, float, float>& data,
-                                Vector<float>& b, Vector<float>& x, Vector<float>& xexact);
+                                Vector<float>& b, Vector<float>& x, Vector<float>& xexact, const HPGMP_gen_opts&);
 
 template int OptimizeProblemELL(SparseMatrix<float>& A, GMRESData<double, double, double>& data,
-                                Vector<double>& b, Vector<double>& x, Vector<double>& xexact);
+                                Vector<double>& b, Vector<double>& x, Vector<double>& xexact, const HPGMP_gen_opts&);
 
 template int OptimizeProblemELL(SparseMatrix<double, float>& A, GMRESData<double, float, float>& data,
-                                Vector<double>& b, Vector<double>& x, Vector<double>& xexact);
+                                Vector<double>& b, Vector<double>& x, Vector<double>& xexact, const HPGMP_gen_opts&);
 
 template int OptimizeProblemELL(SparseMatrix<double, float>& A, GMRESData<double, float, float>& data,
-                                Vector<float>& b, Vector<float>& x, Vector<float>& xexact);
+                                Vector<float>& b, Vector<float>& x, Vector<float>& xexact, const HPGMP_gen_opts&);
 
 template int OptimizeProblemELL(SparseMatrix<double, float>& A, GMRESData<double, double, double>& data,
-                                Vector<double>& b, Vector<double>& x, Vector<double>& xexact);
+                                Vector<double>& b, Vector<double>& x, Vector<double>& xexact, const HPGMP_gen_opts&);
 
 template int OptimizeProblemELL(SparseMatrix<double, float>& A, GMRESData<double, double, double>& data,
-                                Vector<float>& b, Vector<float>& x, Vector<float>& xexact);
+                                Vector<float>& b, Vector<float>& x, Vector<float>& xexact, const HPGMP_gen_opts&);
 
 #if 0
 template <typename scalar_t>
@@ -296,11 +291,11 @@ void seemingly_necessary_stuff_from_reference(SparseMatrix<scalar_t>* M)
 
 // Helper function (see OptimizeProblem.hpp for details)
 template<class SparseMatrix_type>
-double OptimizeProblemMemoryUse(const SparseMatrix_type& A)
+double OptimizeProblemMemoryUse(const SparseMatrix_type& A, const HPGMP_gen_opts&)
 {
     return 0.0;
 }
 
-template double OptimizeProblemMemoryUse(const SparseMatrix<double>&);
-template double OptimizeProblemMemoryUse(const SparseMatrix<float>&);
-template double OptimizeProblemMemoryUse(const SparseMatrix<double, float>&);
+template double OptimizeProblemMemoryUse(const SparseMatrix<double>&, const HPGMP_gen_opts&);
+template double OptimizeProblemMemoryUse(const SparseMatrix<float>&, const HPGMP_gen_opts&);
+template double OptimizeProblemMemoryUse(const SparseMatrix<double, float>&, const HPGMP_gen_opts&);

--- a/src/optimize_problem_ell_rb.cpp
+++ b/src/optimize_problem_ell_rb.cpp
@@ -61,6 +61,9 @@ template<typename local_scalar_t, typename halo_scalar_t, class GMRESData_type, 
 int OptimizeProblemELL(SparseMatrix<local_scalar_t, halo_scalar_t>& A, GMRESData_type& data,
                        Vector<vec_scalar_t>& b, Vector<vec_scalar_t>& x, Vector<vec_scalar_t>& xexact)
 {
+
+    HPGMP_RANGE_PUSH(__FUNCTION__);
+
     b.update_device_data();
     xexact.update_device_data();
 
@@ -125,6 +128,8 @@ int OptimizeProblemELL(SparseMatrix<local_scalar_t, halo_scalar_t>& A, GMRESData
     // Update host mirrors with permutted values
     b.update_host_mirror();
     xexact.update_host_mirror();
+
+    HPGMP_RANGE_POP(__FUNCTION__);
 
     return 0;
 }

--- a/src/optimize_problem_ref.cpp
+++ b/src/optimize_problem_ref.cpp
@@ -46,7 +46,7 @@
 */
 template<class SparseMatrix_type, class GMRESData_type, class Vector_type>
 int OptimizeProblem_ref(SparseMatrix_type& A, GMRESData_type& data, Vector_type& b,
-                        Vector_type& x, Vector_type& xexact)
+                        Vector_type& x, Vector_type& xexact, const HPGMP_gen_opts& gopts)
 {
     // This function can be used to completely transform any part of the data structures.
     // Right now it does nothing, so compiling with a check for unused variables results in complaints
@@ -881,7 +881,7 @@ int OptimizeProblem_ref(SparseMatrix_type& A, GMRESData_type& data, Vector_type&
 
 // Helper function (see OptimizeProblem.hpp for details)
 template<class SparseMatrix_type>
-double OptimizeProblemMemoryUse(const SparseMatrix_type& A)
+double OptimizeProblemMemoryUse(const SparseMatrix_type& A, const HPGMP_gen_opts& gopts)
 {
     return 0.0;
 }
@@ -892,17 +892,17 @@ double OptimizeProblemMemoryUse(const SparseMatrix_type& A)
  * --------------- */
 
 template int OptimizeProblem_ref< SparseMatrix<double>, GMRESData<double, double, double>, Vector<double> >(
-    SparseMatrix<double>&, GMRESData<double, double, double>&, Vector<double>&, Vector<double>&, Vector<double>&);
+    SparseMatrix<double>&, GMRESData<double, double, double>&, Vector<double>&, Vector<double>&, Vector<double>&, const HPGMP_gen_opts&);
 
-template double OptimizeProblemMemoryUse< SparseMatrix<double> >(SparseMatrix<double> const&);
+template double OptimizeProblemMemoryUse< SparseMatrix<double> >(SparseMatrix<double> const&, const HPGMP_gen_opts&);
 
 template int OptimizeProblem_ref< SparseMatrix<float>, GMRESData<float, float, float>, Vector<float> >(
-    SparseMatrix<float>&, GMRESData<float, float, float>&, Vector<float>&, Vector<float>&, Vector<float>&);
+    SparseMatrix<float>&, GMRESData<float, float, float>&, Vector<float>&, Vector<float>&, Vector<float>&, const HPGMP_gen_opts&);
 
-template double OptimizeProblemMemoryUse< SparseMatrix<float> >(SparseMatrix<float> const&);
+template double OptimizeProblemMemoryUse< SparseMatrix<float> >(SparseMatrix<float> const&, const HPGMP_gen_opts&);
 
 // mixed-precision
 template int OptimizeProblem_ref< SparseMatrix<float>, GMRESData<double, double, double>, Vector<double> >(
-    SparseMatrix<float>&, GMRESData<double, double, double>&, Vector<double>&, Vector<double>&, Vector<double>&);
+    SparseMatrix<float>&, GMRESData<double, double, double>&, Vector<double>&, Vector<double>&, Vector<double>&, const HPGMP_gen_opts&);
 
 //#endif // HPGMPG_REFERENCE

--- a/src/prolongation.dev.cpp
+++ b/src/prolongation.dev.cpp
@@ -42,7 +42,7 @@ template<unsigned int BLOCKSIZE, typename local_scalar_t, typename halo_scalar_t
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_prolongation(const local_int_t size,
                                         const local_int_t* __restrict__ f2cOperator,
-                                        const local_scalar_t* __restrict__ coarse,
+                                        const halo_scalar_t* __restrict__ coarse,
                                         vec_scalar_t* __restrict__ fine,
                                         const local_int_t* __restrict__ perm_fine,
                                         const local_int_t* __restrict__ perm_coarse)

--- a/src/prolongation.dev.cpp
+++ b/src/prolongation.dev.cpp
@@ -38,11 +38,11 @@
 
 #include "kernel_helpers.hpp.inc"
 
-template<unsigned int BLOCKSIZE, typename mat_scalar_type, typename vec_scalar_t>
+template<unsigned int BLOCKSIZE, typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_prolongation(const local_int_t size,
                                         const local_int_t* __restrict__ f2cOperator,
-                                        const mat_scalar_type* __restrict__ coarse,
+                                        const local_scalar_t* __restrict__ coarse,
                                         vec_scalar_t* __restrict__ fine,
                                         const local_int_t* __restrict__ perm_fine,
                                         const local_int_t* __restrict__ perm_coarse)
@@ -78,13 +78,14 @@ int prolongation(const SparseMatrix<local_scalar_t, halo_scalar_t>& Af, Vector<v
     dim3 blocks((Af.mgData->rc->local_length() - 1) / 128 + 1);
     dim3 threads(128);
 
-    kernel_prolongation<128><<<blocks, threads, 0, stream_interior>>>(
-        Af.mgData->rc->local_length(),
-        Af.mgData->d_f2cOperator,
-        Af.mgData->xc->d_values(),
-        xf.d_values(),
-        Af.perm,
-        Af.Ac->perm);
+    kernel_prolongation<128, local_scalar_t, halo_scalar_t, vec_scalar_t>
+        <<<blocks, threads, 0, stream_interior>>>(
+            Af.mgData->rc->local_length(),
+            Af.mgData->d_f2cOperator,
+            Af.mgData->xc->d_values(),
+            xf.d_values(),
+            Af.perm,
+            Af.Ac->perm);
 
     Af.dctx->synchronize_compute_stream();
     return 0;

--- a/src/restriction.dev.cpp
+++ b/src/restriction.dev.cpp
@@ -40,33 +40,35 @@
 
 #include "kernel_helpers.hpp.inc"
 
-#define LAUNCH_FUSED_RESTRICT_SPMV(blocksize, width)                                                                         \
-    {                                                                                                                        \
-        dim3 blocks((A.mgData->rc->local_length() - 1) / blocksize + 1);                                                     \
-        dim3 threads(blocksize);                                                                                             \
-                                                                                                                             \
-        kernel_fused_restrict_spmv<blocksize, width, local_scalar_t, vec_scalar_t><<<blocks, threads, 0, stream_interior>>>( \
-            A.mgData->rc->local_length(),                                                                                    \
-            A.mgData->d_f2cOperator,                                                                                         \
-            rf.d_values(),                                                                                                   \
-            A.localNumberOfRows,                                                                                             \
-            A.localNumberOfColumns,                                                                                          \
-            mat->get_ld_indices(), mat->get_ld_values(),                                                                     \
-            mat->get_col_idxs(),                                                                                             \
-            mat->get_values(),                                                                                               \
-            xf.d_values(),                                                                                                   \
-            A.mgData->rc->d_values(),                                                                                        \
-            A.perm,                                                                                                          \
-            A.Ac->perm);                                                                                                     \
+#define LAUNCH_FUSED_RESTRICT_SPMV(blocksize, width)                                              \
+    {                                                                                             \
+        dim3 blocks((A.mgData->rc->local_length() - 1) / blocksize + 1);                          \
+        dim3 threads(blocksize);                                                                  \
+                                                                                                  \
+        kernel_fused_restrict_spmv<blocksize, width, local_scalar_t, halo_scalar_t, vec_scalar_t> \
+            <<<blocks, threads, 0, stream_interior>>>(                                            \
+                A.mgData->rc->local_length(),                                                     \
+                A.mgData->d_f2cOperator,                                                          \
+                rf.d_values(),                                                                    \
+                A.localNumberOfRows,                                                              \
+                A.localNumberOfColumns,                                                           \
+                mat->get_ld_indices(),                                                            \
+                mat->get_ld_values(),                                                             \
+                mat->get_col_idxs(),                                                              \
+                mat->get_values(),                                                                \
+                xf.d_values(),                                                                    \
+                A.mgData->rc->d_values(),                                                         \
+                A.perm,                                                                           \
+                A.Ac->perm);                                                                      \
     }
 
-template<unsigned int BLOCKSIZE, typename local_scalar_t, typename vec_scalar_t>
+template<unsigned int BLOCKSIZE, typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_restrict(local_int_t size,
                                     const local_int_t* __restrict__ f2cOperator,
                                     const vec_scalar_t* __restrict__ fine,
-                                    const local_scalar_t* __restrict__ data,
-                                    local_scalar_t* __restrict__ coarse,
+                                    const halo_scalar_t* __restrict__ data,
+                                    halo_scalar_t* __restrict__ coarse,
                                     const local_int_t* __restrict__ perm_fine,
                                     const local_int_t* __restrict__ perm_coarse)
 {
@@ -75,20 +77,22 @@ __launch_bounds__(BLOCKSIZE)
         return;
     }
     const local_int_t idx_fine      = perm_fine[f2cOperator[idx_coarse]];
-    coarse[perm_coarse[idx_coarse]] = fine[idx_fine] - data[idx_fine];
+    coarse[perm_coarse[idx_coarse]] = static_cast<halo_scalar_t>(fine[idx_fine]) - data[idx_fine];
 }
 
-template<unsigned int BLOCKSIZE, unsigned int WIDTH, typename local_scalar_t, typename vec_scalar_t>
+template<unsigned int BLOCKSIZE, unsigned int WIDTH, typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
 __launch_bounds__(BLOCKSIZE)
     __global__ void kernel_fused_restrict_spmv(const local_int_t size,
                                                const local_int_t* f2cOperator,
                                                const vec_scalar_t* r_fine,
-                                               const local_int_t m, const local_int_t n,
-                                               const int ldi, const int ldv,
+                                               const local_int_t m,
+                                               const local_int_t n,
+                                               const int ldi,
+                                               const int ldv,
                                                const local_int_t* __restrict__ ell_col_ind,
                                                const local_scalar_t* ell_val,
                                                const vec_scalar_t* xf,
-                                               local_scalar_t* r_coarse,
+                                               halo_scalar_t* r_coarse,
                                                const local_int_t* __restrict__ perm_fine,
                                                const local_int_t* __restrict__ perm_coarse)
 {
@@ -113,8 +117,7 @@ __launch_bounds__(BLOCKSIZE)
                       xf[col], sum);
         }
     }
-    // TODO: Would need to change the MGData vector type to avoid the static_cast
-    __stcg(r_coarse + idx_perm_coarse, static_cast<local_scalar_t>(sum));
+    __stcg(r_coarse + idx_perm_coarse, static_cast<halo_scalar_t>(sum));
 }
 
 template<unsigned int BLOCKSIZE, typename local_scalar_t, typename halo_scalar_t, typename vec_scalar_t>
@@ -123,12 +126,13 @@ __launch_bounds__(BLOCKSIZE)
                                                     const local_int_t n,
                                                     const local_int_t* __restrict__ c2fOperator,
                                                     const local_int_t halo_width,
-                                                    const int ldi, const int ldv,
+                                                    const int ldi,
+                                                    const int ldv,
                                                     const local_int_t* __restrict__ halo_row_ind,
                                                     const local_int_t* __restrict__ halo_col_ind,
                                                     const halo_scalar_t* __restrict__ halo_val,
                                                     const vec_scalar_t* __restrict__ xf,
-                                                    local_scalar_t* __restrict__ coarse,
+                                                    halo_scalar_t* __restrict__ coarse,
                                                     const local_int_t* __restrict__ perm_coarse)
 {
     const local_int_t row = blockIdx.x * BLOCKSIZE + threadIdx.x;
@@ -149,10 +153,10 @@ __launch_bounds__(BLOCKSIZE)
         local_int_t col = halo_col_ind[p * ldi + row];
 
         if (col >= 0 && col < n) {
-            sum = fma(halo_val[p * ldv + row], xf[col], sum);
+            sum = fma(static_cast<vec_scalar_t>(halo_val[p * ldv + row]), xf[col], sum);
         }
     }
-    coarse[perm_coarse[idx_coarse]] -= sum;
+    coarse[perm_coarse[idx_coarse]] -= static_cast<halo_scalar_t>(sum);
 }
 
 /*!
@@ -174,7 +178,7 @@ int restriction(const SparseMatrix<local_scalar_t, halo_scalar_t>& A, const Vect
     dim3 blocks((A.mgData->rc->local_length() - 1) / 128 + 1);
     dim3 threads(128);
 
-    kernel_restrict<128, local_scalar_t, vec_scalar_t><<<blocks, threads, 0, stream_interior>>>(
+    kernel_restrict<128, local_scalar_t, halo_scalar_t, vec_scalar_t><<<blocks, threads, 0, stream_interior>>>(
         A.mgData->rc->local_length(),
         A.mgData->d_f2cOperator,
         rf.d_values(),
@@ -228,12 +232,17 @@ int fused_spmv_restriction(const SparseMatrix<local_scalar_t, halo_scalar_t>& A,
                                                                                             threads,
                                                                                             0,
                                                                                             stream_interior>>>(
-            mat->get_num_halo_rows(), mat->get_local_num_cols(),
+            mat->get_num_halo_rows(),
+            mat->get_local_num_cols(),
             A.mgData->d_c2fOperator,
-            mat->get_ell_width(), mat->get_halo_ld_indices(), mat->get_halo_ld_values(),
-            mat->get_halo_row_indices(), mat->get_halo_col_idxs(),
+            mat->get_ell_width(),
+            mat->get_halo_ld_indices(),
+            mat->get_halo_ld_values(),
+            mat->get_halo_row_indices(),
+            mat->get_halo_col_idxs(),
             mat->get_halo_values(),
-            xf.d_values(), A.mgData->rc->d_values(),
+            xf.d_values(),
+            A.mgData->rc->d_values(),
             A.Ac->perm);
     }
 #endif

--- a/unittesting/dot.cpp
+++ b/unittesting/dot.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[])
         MPI_Abort(MPI_COMM_WORLD, -1);
     }
 #endif
-    HPGMP_Init(&argc, &argv);
+    const HPGMP_gen_opts gopts = HPGMP_Init(&argc, &argv);
 
     int myRank = 0;
 #ifndef HPGMP_NO_MPI
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
     if (myRank < sizeValidComm) {
         global_failure = ValidGMRES<scalar_type, scalar_type2, project_type>(
             argc, argv, validation_t::standard, validation_comm, ctx.get(), numberOfMgLevels, verbose,
-            test_data);
+            test_data, gopts);
     }
 
 
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
 
         Vector_type b, x;
         SetupProblem("bench_", argc, argv, benchmark_comm, ctx.get(), numberOfMgLevels, verbose, geom,
-                     A, data, A_lo, data_lo, b, x, test_data);
+                     A, data, A_lo, data_lo, b, x, test_data, gopts);
 
         const auto nrow = A.localNumberOfRows;
         x.fill_random();

--- a/unittesting/gs_multicolor.cpp
+++ b/unittesting/gs_multicolor.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* argv[])
 #ifndef HPGMP_NO_MPI
     MPI_Init(&argc, &argv);
 #endif
-    HPGMP_Init(&argc, &argv);
+    const HPGMP_gen_opts gopts = HPGMP_Init(&argc, &argv);
 #ifndef HPGMP_NO_MPI
     MPI_Comm bench_comm = MPI_COMM_WORLD;
 #else
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
 
     // Call user-tunable set up function.
     double t7 = mytimer();
-    OptimizeProblem(A, data, b, x, xexact);
+    OptimizeProblem(A, data, b, x, xexact, gopts);
     t7       = mytimer() - t7;
     times[7] = t7;
 

--- a/unittesting/test_ginkgo.cpp
+++ b/unittesting/test_ginkgo.cpp
@@ -266,7 +266,7 @@ int main(int argc, char* argv[])
     auto gko_mat =
         gko::share(gko_mat_type::create_const(gko_exec,
                                               gko::dim<2>{static_cast<gko::size_type>(mat_ptr->get_local_num_rows()),
-                                                          static_cast<gko::size_type>(mat_ptr->get_local_num_cols())},
+                                                          static_cast<gko::size_type>(mat_ptr->get_local_num_rows())},
                                               gko::make_const_array_view(gko_exec,
                                                                          mat_ptr->get_ld_values() * mat_ptr->get_ell_width(),
                                                                          mat_ptr->get_values()),

--- a/unittesting/test_ginkgo.cpp
+++ b/unittesting/test_ginkgo.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
 #ifndef HPGMP_NO_MPI
     MPI_Init(&argc, &argv);
 #endif
-    HPGMP_Init(&argc, &argv);
+    const HPGMP_gen_opts gopts = HPGMP_Init(&argc, &argv);
 #ifndef HPGMP_NO_MPI
     MPI_Comm bench_comm = MPI_COMM_WORLD;
 #else
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
 
     // Call user-tunable set up function.
     double t7 = mytimer();
-    OptimizeProblem(A, data, b, x, xexact);
+    OptimizeProblem(A, data, b, x, xexact, gopts);
     t7       = mytimer() - t7;
     times[7] = t7;
 

--- a/unittesting/test_ginkgo.cpp
+++ b/unittesting/test_ginkgo.cpp
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
     using gko_vec_type = gko::matrix::Dense<scalar_type>;
     using gko_ell_type = gko::matrix::Ell<scalar_type, local_int_t>;
     using gko_coo_type = gko::matrix::Coo<scalar_type, local_int_t>;
-    auto gko_exec      = create_ginkgo_executor();
+    auto gko_exec      = create_ginkgo_executor(dctx->get_compute_stream());
 #ifdef HPGMP_REFERENCE
     using gko_mat_type = gko_coo_type;
     auto gko_mat =
@@ -233,8 +233,8 @@ int main(int argc, char* argv[])
         size_t mat_col_bytes          = mat_ptr->get_ld_indices() * mat_ptr->get_ell_width() * sizeof(local_int_t);
         scalar_type* h_tmp_mat_values = (scalar_type*)malloc(mat_values_bytes);
         local_int_t* h_tmp_col_values = (local_int_t*)malloc(mat_col_bytes);
-        dctx.get()->copy_device_to_host_sync((void*)h_tmp_mat_values, mat_ptr->get_values(), mat_values_bytes);
-        dctx.get()->copy_device_to_host_sync((void*)h_tmp_col_values, mat_ptr->get_col_idxs(), mat_col_bytes);
+        dctx->copy_device_to_host_sync((void*)h_tmp_mat_values, mat_ptr->get_values(), mat_values_bytes);
+        dctx->copy_device_to_host_sync((void*)h_tmp_col_values, mat_ptr->get_col_idxs(), mat_col_bytes);
         std::cout << "ELL matrix column indices (copied to host): (First 20 rows)\n";
         for (local_int_t row = 0; row < 20; ++row)
         {

--- a/unittesting/test_spmv.cpp
+++ b/unittesting/test_spmv.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
 #ifndef HPGMP_NO_MPI
     MPI_Init(&argc, &argv);
 #endif
-    HPGMP_Init(&argc, &argv);
+    const HPGMP_gen_opts gopts = HPGMP_Init(&argc, &argv);
 #ifndef HPGMP_NO_MPI
     MPI_Comm bench_comm = MPI_COMM_WORLD;
 #else
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
 
     // Call user-tunable set up function.
     double t7 = mytimer();
-    OptimizeProblem(A, data, b, x, xexact);
+    OptimizeProblem(A, data, b, x, xexact, gopts);
     t7       = mytimer() - t7;
     times[7] = t7;
 


### PR DESCRIPTION
- Adds a kernel to perform the halo part of the Gauss Seidel sweeps when using Ginkgo.
- Adds necessary fixes to instantiate `AMP<double>` while keeping the projection in single precision. Uses updates on the Ginkgo side to perform mixed-precision SpMV and FwdGaussSeidel.

Some preliminary results with a $320^3$ grid per rank and 2 ranks (AMP tolerance is 1e-8):

Native implementation with `Ell<double>` and `Ell<float>` 
```
Validate GMRES at full scale( tol = 1e-09, max iters = 10000 and restart = 30 ) <<
ValidGMRES: Reference Iteration count = 1031
ValidGMRES: Optimized iteration count = 1032
 BenchGMRES: Main benchmark time = 1.56374s
 BenchGMRES: Reference time = 2.82076s
```

Ginkgo implementation with `Ell<double>` and `Ell<float>` 
```
Validate GMRES at full scale( tol = 1e-09, max iters = 10000 and restart = 30 ) <<
ValidGMRES: Reference Iteration count = 979
ValidGMRES: Optimized iteration count = 979
 BenchGMRES: Main benchmark time = 2.26858s
 BenchGMRES: Reference time = 3.89275s
```

Ginkgo implementation with `Ell<double>` and `Amp<double>` 
```
Validate GMRES at full scale( tol = 1e-09, max iters = 10000 and restart = 30 ) <<
ValidGMRES: Reference Iteration count = 979
ValidGMRES: Optimized iteration count = 979
 BenchGMRES: Main benchmark time = 2.32089s
 BenchGMRES: Reference time = 3.80961s
```